### PR TITLE
fix(ui): Fix clipping app options on small screens

### DIFF
--- a/web/src/main/webapp/my-app/layout/partials/app-header-options.html
+++ b/web/src/main/webapp/my-app/layout/partials/app-header-options.html
@@ -22,7 +22,7 @@
   <div ng-if="renderMe">
     <!-- MEDIUM AND LARGE SCREENS -->
     <div layout="row" layout-align="end center" hide-xs>
-      <md-button ng-href="apps" class="md-primary">
+      <md-button ng-href="apps" class="md-primary" aria-label="Add more apps to home">
         <span ng-if="GuestMode">
           <md-icon>explore</md-icon> Browse {{ portal.theme.title }}
         </span>
@@ -52,7 +52,7 @@
             <md-icon>explore</md-icon>
             <span>Browse {{ portal.theme.title }}</span>
           </md-button>
-          <md-button ng-href="apps" ng-if="!GuestMode">
+          <md-button ng-href="apps" ng-if="!GuestMode" aria-label="Add more apps to home">
             <md-icon>add</md-icon>
             <span>Add more to home</span>
           </md-button>

--- a/web/src/main/webapp/my-app/layout/partials/app-header-options.html
+++ b/web/src/main/webapp/my-app/layout/partials/app-header-options.html
@@ -26,8 +26,11 @@
         <span ng-if="GuestMode">
           <md-icon>explore</md-icon> Browse {{ portal.theme.title }}
         </span>
-        <span ng-if="!GuestMode">
+        <span ng-if="!GuestMode" hide-sm>
           <md-icon>add</md-icon> Add more to home
+        </span>
+        <span ng-if="!GuestMode" hide-gt-sm>
+          <md-icon>add</md-icon> Add more
         </span>
       </md-button>
       <md-switch class="md-accent app-header-toggle" ng-model="expandedMode" ng-controller="ToggleController"
@@ -39,27 +42,27 @@
 
     <!-- SMALL SCREENS -->
     <md-menu md-position-mode="target-right bottom" hide-gt-xs>
-      <md-button aria-label="Open options menu" class="md-primary link-div" ng-click="$mdOpenMenu($event)">
+      <md-button aria-label="Open options menu" class="link-div" ng-click="$mdOpenMenu($event)">
         <span layout="row" layout-align="center center"><md-icon>settings</md-icon></span>
         <md-tooltip class="top-bar-tooltip" md-direction="bottom" md-delay="500">Options</md-tooltip>
       </md-button>
       <md-menu-content width="5">
         <md-menu-item>
-          <md-button ng-href="apps" class="md-primary">
-            <span ng-if="GuestMode">
-              <md-icon>explore</md-icon> Browse {{ portal.theme.title }}
-            </span>
-            <span ng-if="!GuestMode">
-              <md-icon>add</md-icon> Add more to home
-            </span>
+          <md-button ng-href="apps" ng-if="GuestMode">
+            <md-icon>explore</md-icon>
+            <span>Browse {{ portal.theme.title }}</span>
+          </md-button>
+          <md-button ng-href="apps" ng-if="!GuestMode">
+            <md-icon>add</md-icon>
+            <span>Add more to home</span>
           </md-button>
         </md-menu-item>
-        <md-menu-item>
-          <md-switch class="md-accent app-header-toggle" ng-model="expandedMode" ng-controller="ToggleController"
-                     aria-label="Toggle expanded widget layout" ng-change="toggleMode(expandedMode)"
-                     style="margin-top:0;margin-bottom:0;color:#fff;">
-            <span>Expand widgets</span>
-          </md-switch>
+        <md-menu-item ng-controller="ToggleController">
+          <md-button ng-click="toggleMode(!expandedMode)">
+            <md-icon>widgets</md-icon>
+            <span ng-if="!expandedMode">Show expanded widgets</span>
+            <span ng-if="expandedMode">Show compact widgets</span>
+          </md-button>
         </md-menu-item>
       </md-menu-content>
     </md-menu>


### PR DESCRIPTION
**In this PR**:
- In mobile app options, replace widget toggle with regular menu item
- Change "add more to home" => "add more" on small screens to avoid clipping

### Screenshots
![screen shot 2017-09-28 at 11 48 42 am](https://user-images.githubusercontent.com/5818702/30979479-5cd4ccea-a443-11e7-8813-7ced4f66f6ef.png)
![screen shot 2017-09-28 at 11 48 49 am](https://user-images.githubusercontent.com/5818702/30979478-5cd4586e-a443-11e7-8a4a-26a89bccaf1d.png)
![screen shot 2017-09-28 at 11 48 57 am](https://user-images.githubusercontent.com/5818702/30979482-5cfd8900-a443-11e7-8483-4151b94ec71e.png)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
