### PR TITLE
Use name `uPortal-home` consistently

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to `uPortal Home`
+# Contributing to `uPortal-home`
 
 In short:
 
@@ -15,7 +15,7 @@ The [Apereo Welcoming Policy][] [applies][code of conduct].
 
 ## Contributor License Agreements
 
-As an [incubating, aspiring Apereo product][uPortal Home website on incubating], `uPortal Home` requires contributors and contributions to comply with [Apereo inbound intellectual property licensing practices][].
+As an [incubating, aspiring Apereo product][uPortal-home website on incubating], `uPortal-home` requires contributors and contributions to comply with [Apereo inbound intellectual property licensing practices][].
 
 The short version:
 
@@ -81,7 +81,7 @@ The [code of conduct][] is not negotiable. Please do be kind.
 Everything else the project participants welcome helping you to work through in your contributions.
 
 
-[uPortal Home website on incubating]: http://uportal-project.github.io/uportal-home/apereo-incubation.html
+[uPortal-home website on incubating]: http://uportal-project.github.io/uportal-home/apereo-incubation.html
 [Apereo CLA roster]: http://licensing.apereo.org/completed-clas
 [Apereo Corporate Contributor License Agreement]: https://www.apereo.org/sites/default/files/Licensing%20Agreements/apereo-ccla.pdf
 [Apereo inbound intellectual property licensing practices]: https://www.apereo.org/licensing/practices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * [Update references to github repos](https://github.com/uPortal-Project/uportal-home/pull/706)
 
 ## [7.0.0][] - 2017-09-27
-* Changing name from angularjs-portal to uportal-home
+* Changing name from angularjs-portal to uPortal-home
 
 ## [6.7.0][] - 2017-09-26
 ### Minor Changes

--- a/NOTICE
+++ b/NOTICE
@@ -50,7 +50,6 @@ This project includes:
         Common Development And Distribution License (CDDL) Version 1.0
   tomcat-util under Apache License, Version 2.0
   uPortal Application Framework under The Apache License, Version 2.0
-  uPortal Home under The Apache License, Version 2.0
-  uPortal Home Mock Portal under The Apache License, Version 2.0
-  uPortal Home Parent Project under The Apache License, Version 2.0
-
+  uPortal-home under The Apache License, Version 2.0
+  uPortal-home Mock Portal under The Apache License, Version 2.0
+  uPortal-home Parent Project under The Apache License, Version 2.0

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This is an Angular approach to the dashboard view of uPortal. This dashboard wil
 
 See [this project's documentation][GitHub Pages site].
 
-#### Resources for understanding what you can do with `uportal-home`:
+#### Resources for understanding what you can do with `uPortal-home`:
 
 + [MyUW Overview slide deck][]
 + [MyUW Introduction YouTube video](https://www.youtube.com/watch?v=4kM9pPnH_hA)
@@ -51,7 +51,7 @@ See [documentation site][GitHub Pages site].
 ### Modules
 
 #### Frame
-uPortal Home is a [uPortal App-Framework project](https://github.com/uPortal-Project/uportal-app-framework).
+uPortal-home is a [uPortal App-Framework project](https://github.com/uPortal-Project/uportal-app-framework).
 
 #### Home
 This is the portal home page. It uses the frame as a base then adds in the layout, app directory, and features pages.

--- a/build.sh
+++ b/build.sh
@@ -45,7 +45,7 @@ fi
 
 unamestr=`uname`
 if [[ "$unamestr" == 'Linux' ]]; then
- notify-send "Build complete for uportal-home"
+ notify-send "Build complete for uPortal-home"
 elif [[ "$unamestr" == 'Darwin' ]]; then
- osascript -e 'display notification "uportal-home build.sh finished" with title "uPortal Home deployed" sound name "Hero"'
+ osascript -e 'display notification "uPortal-home build.sh finished" with title "uPortal-home deployed" sound name "Hero"'
 fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
 Questions? [Get in touch][uportal-user@].
 
-This documentation describes [uPortal Home](https://github.com/uPortal-Project/uportal-home), the free and open source alternative front end for [uPortal][], used in e.g. [MyUW](https://it.wisc.edu/services/myuw/). uPortal Home is based on [uPortal App-Framework](https://github.com/uPortal-Project/uportal-app-framework) (which has [its own documentation](http://uportal-project.github.io/uportal-app-framework/)).
+This documentation describes [uPortal-home](https://github.com/uPortal-Project/uportal-home), the free and open source alternative front end for [uPortal][], used in e.g. [MyUW](https://it.wisc.edu/services/myuw/). uPortal-home is based on [uPortal App-Framework](https://github.com/uPortal-Project/uportal-app-framework) (which has [its own documentation](http://uportal-project.github.io/uportal-app-framework/)).
 
-[uPortal Home is an Apereo Incubating project](apereo-incubation.md) in the uPortal ecosystem.
+[uPortal-home is an Apereo Incubating project](apereo-incubation.md) in the uPortal ecosystem.
 
 [![Apereo Incubating badge](https://www.apereo.org/sites/default/files/Incubation%20Logos/incubating%20w%20logo%2015MAR17.png)](https://www.apereo.org/content/projects-currently-incubation)
 
@@ -26,12 +26,12 @@ Of course for a more sophisticated demo or to adopt for real you will need to [c
 #### Persistent layout of widgets
 The home page presents widgets in a remembered order. Logged in users can add to, remove from, and re-order this list.
 
-Under the hood, the home page layout is implemented as a personalized layout fragment in [uPortal][]'s `DLM`, so uPortal Home delivers (and updates) a
+Under the hood, the home page layout is implemented as a personalized layout fragment in [uPortal][]'s `DLM`, so uPortal-home delivers (and updates) a
 default set and ordering of home page content that is filtered to the viewing user's permissions.
 
 #### Toggleable view modes
 
-Widgets show on the home page in either a minimalist "compact mode" or a rich "expanded mode". uPortal Home takes a guess at the best default mode for a given browser and users can toggle the mode, with their preference stored in browser local storage.
+Widgets show on the home page in either a minimalist "compact mode" or a rich "expanded mode". uPortal-home takes a guess at the best default mode for a given browser and users can toggle the mode, with their preference stored in browser local storage.
 
 + [Expanded mode](expanded.md)
 + [Compact mode](compact.md)

--- a/docs/_includes/footer-aside.html
+++ b/docs/_includes/footer-aside.html
@@ -22,12 +22,12 @@
   <h5>Google groups</h5>
   <ul>
     <li><a href="https://groups.google.com/forum/#!forum/myuw-developers">MyUW Developers</a>:
-      <small>All things uPortal Home in the MyUW context</small>
+      <small>All things uPortal-home in the MyUW context</small>
     </li>
     <li><a href="https://groups.google.com/a/apereo.org/forum/#!forum/uportal-dev">uportal-dev@</a>:
-      <small> uPortal Home development in the uPortal context</small></li>
+      <small> uPortal-home development in the uPortal context</small></li>
     <li><a href="https://groups.google.com/a/apereo.org/forum/#!forum/uportal-user">uportal-user@</a>:
-      <small> uPortal Home adoption in the uPortal context</small></li>
+      <small> uPortal-home adoption in the uPortal context</small></li>
   </ul>
 
   <h5>Learn more</h5>

--- a/docs/apereo-incubation.md
+++ b/docs/apereo-incubation.md
@@ -85,7 +85,7 @@ Naming considerations: Names should reflect uPortal commitment and represent how
     + Developers can create their own uPortal Apps drawing from common
       configuration, style and functionality.
   + `angularjs-portal` → `uPortal-home`
-    + uPortal Home will be a standard uPortal App that handles layout of the
+    + uPortal-home will be a standard uPortal App that handles layout of the
       framework widgets for a cohesive user experience.
     + Developers provide `uPortal-home-config` for environment specific
       configuration.

--- a/docs/app-directory.md
+++ b/docs/app-directory.md
@@ -2,7 +2,7 @@
 
 ## App directory philosophy
 
-uPortal Home uses the app directory to scale beyond the limitations of stuffing content into boxes on tabs in an old-school portal. Instead, users are encouraged to search over a directory potentially containing more stuff than would have fit on tabs.
+uPortal-home uses the app directory to scale beyond the limitations of stuffing content into boxes on tabs in an old-school portal. Instead, users are encouraged to search over a directory potentially containing more stuff than would have fit on tabs.
 
 This reduces noise and opportunity cost of adding content to the portal. Content that is only interesting to a smaller population can hang out in the directory, ready to be referenced, found, and used, but not bothering anyone who does not go looking for it.
 
@@ -90,7 +90,7 @@ App directory entries optionally have an icon.
 <parameter><name>faIcon</name><value>fa-user</value></parameter>
 ```
 
-These can be any of the [Font Awesome icons][]. (uPortal Home intends to transition to using [Material icons][] instead in the near future.)
+These can be any of the [Font Awesome icons][]. (uPortal-home intends to transition to using [Material icons][] instead in the near future.)
 
 #### Categories
 
@@ -148,7 +148,7 @@ Optionally an application directory entry can specify an "alternative" URL. This
 </parameter>
 ```
 
-Where the external URL is specified, uPortal Home will prefer "Launch"ing to the external URL rather than launching to the internal portlet.
+Where the external URL is specified, uPortal-home will prefer "Launch"ing to the external URL rather than launching to the internal portlet.
 
 ### Permissions
 
@@ -227,7 +227,7 @@ Users with `MANAGE` permission over an app directory entry can exercise the JSON
 
 ## App directory implementation details
 
-Currently, the uPortal Home app directory *is* the uPortal portlet registry.
+Currently, the uPortal-home app directory *is* the uPortal portlet registry.
 
 This means that the app directory can be viewed and edited via the Portlet Manager tooling in uPortal and that app directory entries are uPortal "entities" bulk loaded via entity import.
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,8 +1,8 @@
-# Search in uPortal Home
+# Search in uPortal-home
 
 ## Search philosophy
 
-uPortal Home uses search to scale beyond the limitations of stuffing content into boxes on tabs in an old-school portal. Instead, users are encouraged to search over a directory potentially containing more stuff than would have fit on tabs.
+uPortal-home uses search to scale beyond the limitations of stuffing content into boxes on tabs in an old-school portal. Instead, users are encouraged to search over a directory potentially containing more stuff than would have fit on tabs.
 
 ## What you can Search
 
@@ -75,7 +75,7 @@ Search is configured in `web-config.js`:
 ...
 ```
 
-You declare one or more search configurations.  A search configuration has a `group`. The first search configuration matching a user's groups will apply to that user's uPortal Home experience.
+You declare one or more search configurations.  A search configuration has a `group`. The first search configuration matching a user's groups will apply to that user's uPortal-home experience.
 
 Within each search configuration, you can set:
 

--- a/mock-portal/pom.xml
+++ b/mock-portal/pom.xml
@@ -28,7 +28,7 @@
   
   <artifactId>uportal-home-mock-portal</artifactId>
   <packaging>war</packaging>
-  <name>uPortal Home Mock Portal</name>
+  <name>uPortal-home Mock Portal</name>
   <description>Mock Portal Environment</description>
   
   <build>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uportal/home",
   "version": "7.0.1",
-  "description": "uPortal Home",
+  "description": "uPortal-home",
   "scripts": {
     "commitmsg": "commitlint -e",
     "cz": "git-cz",
@@ -28,7 +28,7 @@
     "url": "https://github.com/uPortal-Project/uportal-home.git"
   },
   "author": {
-    "name": "uPortal Home Developers",
+    "name": "uPortal-home Developers",
     "email": "uportal-dev@apereo.org",
     "url": "https://github.com/uPortal-Project/"
   },

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <artifactId>uportal-home-parent</artifactId>
   <packaging>pom</packaging>
   <version>7.0.3-SNAPSHOT</version>
-  <name>uPortal Home Parent Project</name>
+  <name>uPortal-home Parent Project</name>
   <description>An alternative homepage for uPortal</description>
   <url>https://github.com/uPortal-Project/uportal-home</url>
   

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -20,7 +20,7 @@
 -->
 <html>
   <head>
-    <title>uportal-home ROOT redirect</title>
+    <title>uPortal-home ROOT redirect</title>
     <META http-equiv="refresh" content="5;URL=/web">
   </head>
   <body bgcolor="#ffffff">

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -29,7 +29,7 @@
 
   <artifactId>uportal-home</artifactId>
   <packaging>war</packaging>
-  <name>uPortal Home</name>
+  <name>uPortal-home</name>
 
   <url>https://github.com/uPortal-Project/uportal-home</url>
   <properties>

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -27,7 +27,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
     version="2.5">
-  <display-name>uPortal Home</display-name>
+  <display-name>uPortal-home</display-name>
 
   <context-param>
         <param-name>contextClass</param-name>

--- a/web/src/main/webapp/js/README.md
+++ b/web/src/main/webapp/js/README.md
@@ -1,6 +1,6 @@
 # What are these files?
 
-(This is not comprehensive documentation on how to configure uPortal Home -- see the documentation site both for this project and [for the `uPortal-app-framework` project][uPortal-app-framework configuration docs] it overlays upon. Rather, this is directory-local reminder of what these files are.)
+(This is not comprehensive documentation on how to configure uPortal-home -- see the documentation site both for this project and [for the `uPortal-app-framework` project][uPortal-app-framework configuration docs] it overlays upon. Rather, this is directory-local reminder of what these files are.)
 
 ## `override.js`
 


### PR DESCRIPTION
Obsessively, consistently brand as `uPortal-home`.

~~Two~~ commits:

+ one for everything except actual artifact identifiers ("documentation"). This mostly won't break anything, though I suppose Jasig's picky `NOTICE` file checker will want downstream `NOTICE` files to reflect the change the next time the picky notice checker plugin runs on those projects.
+ ~~one for actual Maven artifactIds. BREAKING CHANGE. Using a goofy internal capital letter in these may be a bad idea, or at least may be unjustified.~~

~~Leading with thoroughly adopting the branding `uPortal-home` because this new name is young and now is the moment if we're going to do this, but **I could totally see dropping the artifact identifier changing commit from this and just doing the rest of the renaming** so as to not break any work that's been done to use the new artifact IDs and so as to not have weird internal caps in actual artifact IDs. Maybe artifact IDs just really ought to be all-lowercase.~~

Leading with thoroughly adopting the branding `uPortal-home` because this new name is young and now is the moment if we're going to do this, but **not renaming artifact identifies** so as to not break any work that's been done to use the new artifact IDs and so as to not have weird internal caps in actual artifact IDs. Artifact IDs just really ought to be all-lowercase.

For that matter: I'm not actually hung up on exactly what the name formatting is. I'm just hung up on adopting some specific formatting consistently, so that we have a brand.  
+ All-lowercase `uportal-home` would  be fine, I think. It's got different tradeoffs, steps away from the "uPortal" of the brand, but then getting rid of weird internal caps has some advantages. 
+ `uPortal-Home` would be fine. 
+ But I think `uPortal-home` is [what we said we'd do](https://groups.google.com/a/apereo.org/d/msg/uportal-dev/BXOjNeuTC7E/RfFa2_NZFgAJ). ( #609 ), so leading with that on this PR.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
