### PR TITLE
fix: Separate remove button into own controller

### DIFF
--- a/web/src/main/webapp/my-app/layout/partials/remove-button.html
+++ b/web/src/main/webapp/my-app/layout/partials/remove-button.html
@@ -18,9 +18,9 @@
     under the License.
 
 -->
-<md-button ng-controller="LayoutController as layoutCtrl" class="widget-action widget-remove md-icon-button"
+<md-button ng-controller="RemoveWidgetController as removeCtrl" class="widget-action widget-remove md-icon-button"
            aria-label="remove {{ portlet.fname }} widget from your home screen"
-           ng-click="layoutCtrl.removePortlet(portlet.fname)"
+           ng-click="removeCtrl.removePortlet(portlet.fname)"
            ng-hide="GuestMode">
   <md-icon>close</md-icon>
 </md-button>


### PR DESCRIPTION
This is a conflict-free version of #699 

**In this PR**:
- Broke functionality for widget remove button into its own controller
- Replaced jQuery stuff with angular filters or plain javascript

### Why?

The functionality used to live in `LayoutController`, and every instance of a `<remove-button>` in a user's layout was causing `LayoutController` to initialize (including the `getLayout()` service call. It's probably better if each instance of the remove button only initializes what it needs to function.

### Proof that it still works
![remove-button](https://user-images.githubusercontent.com/5818702/31188107-7ab692ec-a8f9-11e7-8fcf-eed6f790aca1.gif)


----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
