### PR TITLE
fix: using mdColors to get primary color in marketplace

### DIFF
--- a/web/src/main/webapp/my-app/marketplace/controllers.js
+++ b/web/src/main/webapp/my-app/marketplace/controllers.js
@@ -28,20 +28,14 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
     ['googleCustomSearchService', 'miscSearchService', 'layoutService',
       '$log', 'marketplaceService', 'miscService', 'MISC_URLS',
       '$sessionStorage', '$localStorage', '$rootScope', '$scope',
-      '$routeParams', '$timeout', '$location',
+      '$routeParams', '$timeout', '$location', '$mdColors',
     function(googleCustomSearchService, miscSearchService, layoutService,
       $log, marketplaceService, miscService, MISC_URLS,
         $sessionStorage, $localStorage, $rootScope, $scope,
-        $routeParams, $timeout, $location) {
+        $routeParams, $timeout, $location, $mdColors) {
       var vm = this;
-      var currentThemePrimary = ($sessionStorage.portal.theme &&
-        $sessionStorage.portal.theme.materialTheme) ?
-        $sessionStorage.portal.theme.materialTheme.primary['500'] :
-        {value: ['0', '0', '0']};
-      $scope.primaryColorRgb = 'rgb('+
-        currentThemePrimary.value[0] + ',' +
-        currentThemePrimary.value[1] + ',' +
-        currentThemePrimary.value[2] + ')';
+      $scope.primaryColorRgb =
+          $mdColors.getThemeColor($rootScope.portal.theme.name + '-primary');
 
       $scope.navToDetails = function(marketplaceEntry, location) {
         marketplaceService.setFromInfo(location, $scope.searchTerm);


### PR DESCRIPTION
This uses the [theme name refactor in uPortal-app-framework](https://github.com/uPortal-Project/uportal-app-framework/pull/568) to simplify getting the current theme's primary color.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
