### PR TITLE
fix: calculating rel on marketplace anchors

### DIFF
--- a/web/src/main/webapp/my-app/marketplace/partials/marketplace-entry.html
+++ b/web/src/main/webapp/my-app/marketplace/partials/marketplace-entry.html
@@ -31,7 +31,7 @@
 		<div ng-hide="GuestMode" hide-xs layout="row">
       <!-- Launch button with access -->
       <md-button class="md-default" aria-label="launch {{::portlet.title}}" ng-href="{{getLaunchURL(portlet)}}"
-                 target="{{::portlet.target}}" ng-if="portlet.canAdd">
+                 target="{{::portlet.target}}" rel="{{::portlet.target | targetToRel}}" ng-if="portlet.canAdd">
         <span class="fa fa-arrow-circle-o-right"></span> Launch
       </md-button>
 
@@ -103,7 +103,7 @@
     <div ng-hide="GuestMode" layout="row" layout-align="end center" class="mp-mobile-buttons">
       <!-- Launch button with access on mobile-->
       <md-button class="md-default" aria-label="launch {{::portlet.title}}" ng-href="{{getLaunchURL(portlet)}}"
-                 target="{{::portlet.target}}" ng-if="portlet.canAdd">
+                 target="{{::portlet.target}}" rel="{{::portlet.target | targetToRel}}" ng-if="portlet.canAdd">
         <span class="fa fa-arrow-circle-o-right"></span> Launch
       </md-button>
 

--- a/web/src/main/webapp/my-app/search/partials/marketplace-results.html
+++ b/web/src/main/webapp/my-app/search/partials/marketplace-results.html
@@ -29,7 +29,7 @@
   No {{portal.theme.title}} results. <a href="apps">Try browsing instead?</a>
 </div>
 <div class="result" ng-repeat="portlet in myuwFilteredResults = (myuwResults | filter:searchTermFilter | showApplicable:showAll | orderBy:sortParameter | limitTo:searchResultLimit)">
-  <h4><a ng-href="{{getLaunchURL(portlet)}}" target="{{::portlet.target}}" target="{{::portlet.target | targetToRel}}">{{ portlet.title }}</a> <small ng-if='GuestMode && !portlet.canAdd'>(login to use)</small></h4>
+  <h4><a ng-href="{{getLaunchURL(portlet)}}" target="{{::portlet.target}}" rel="{{::portlet.target | targetToRel}}">{{ portlet.title }}</a> <small ng-if='GuestMode && !portlet.canAdd'>(login to use)</small></h4>
   <p>{{ portlet.description }}</p>
   <p>
     <md-button ng-click="addToHome(portlet)"

--- a/web/src/main/webapp/my-app/search/partials/marketplace-results.html
+++ b/web/src/main/webapp/my-app/search/partials/marketplace-results.html
@@ -29,7 +29,7 @@
   No {{portal.theme.title}} results. <a href="apps">Try browsing instead?</a>
 </div>
 <div class="result" ng-repeat="portlet in myuwFilteredResults = (myuwResults | filter:searchTermFilter | showApplicable:showAll | orderBy:sortParameter | limitTo:searchResultLimit)">
-  <h4><a ng-href="{{getLaunchURL(portlet)}}" target="{{::portlet.target}}">{{ portlet.title }}</a> <small ng-if='GuestMode && !portlet.canAdd'>(login to use)</small></h4>
+  <h4><a ng-href="{{getLaunchURL(portlet)}}" target="{{::portlet.target}}" target="{{::portlet.target | targetToRel}}">{{ portlet.title }}</a> <small ng-if='GuestMode && !portlet.canAdd'>(login to use)</small></h4>
   <p>{{ portlet.description }}</p>
   <p>
     <md-button ng-click="addToHome(portlet)"


### PR DESCRIPTION
Using a filter to determine if launch links in marketplace should have `noopener noreferrer`

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
