### PR TITLE
Use frame-page directive for all views

### DIFF
--- a/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
+++ b/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
@@ -19,8 +19,7 @@
 
 -->
 <!-- COMPACT MODE -->
-<div class="portlet-frame">
-  <home-header></home-header>
+<frame-page app-title="Home" app-icon="home" app-show-add-to-home="false">
   <div role="main" class="no-padding portlet-body" ng-controller="LayoutController as layoutCtrl">
     <div ng-show="$storage.showFilterOption" style="margin: 15px auto; max-width: 1200px;">
       <div style="margin: 0; padding: 5px;">
@@ -42,4 +41,4 @@
        </li>
     </ul>
   </div>
-</div>
+</frame-page>

--- a/web/src/main/webapp/my-app/layout/partials/default-view.html
+++ b/web/src/main/webapp/my-app/layout/partials/default-view.html
@@ -18,9 +18,8 @@
     under the License.
 
 -->
-<div class="row portlet-frame">
-  <home-header></home-header>
+<frame-page app-title="Home" app-icon="home" app-show-add-to-home="false">
   <div role="main" class="col-xs-12 no-padding portlet-body" ng-controller="DefaultViewController as defaultViewCtrl">
     <loading-gif data-object='loading'></loading-gif>
   </div>
-</div>
+</frame-page>

--- a/web/src/main/webapp/my-app/layout/widget/partials/home-widget-view.html
+++ b/web/src/main/webapp/my-app/layout/widget/partials/home-widget-view.html
@@ -19,8 +19,7 @@
 
 -->
 <!-- HOME-WIDGET-VIEW -->
-<div class="row portlet-frame">
-  <home-header></home-header>
+<frame-page app-title="Home" app-icon="home" app-show-add-to-home="false">
   <div role="main" class="col-xs-12 portlet-body" ng-controller="WidgetController as widgetCtrl">
     <div ng-show='$storage.showFilterOption' style='margin: 15px auto; max-width: 1200px;'>
       <div class='col-xs-12' style='margin: 0; padding: 5px;'>
@@ -36,18 +35,18 @@
       </li>
     </ul>
     <ul class="tile-list" ng-hide='GuestMode'>
-       <li class="col-xs-12 col-sm-6 col-md-4 col-lg-3 no-padding list-container">
-         <div class="widget-frame add-favorites">
-           <a href='apps'>
-             <div class="widget-icon-container">
-               <i class="fa fa-plus"></i>
-             </div>
-             <div class="widget-title">
-               <h4>Add to home</h4>
-             </div>
-           </a>
+      <li class="col-xs-12 col-sm-6 col-md-4 col-lg-3 no-padding list-container">
+        <div class="widget-frame add-favorites">
+          <a href='apps'>
+            <div class="widget-icon-container">
+              <i class="fa fa-plus"></i>
+            </div>
+            <div class="widget-title">
+              <h4>Add to home</h4>
+            </div>
+          </a>
         </div>
-       </li>
+      </li>
     </ul>
   </div>
-</div>
+</frame-page>

--- a/web/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
+++ b/web/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
@@ -18,105 +18,109 @@
     under the License.
 
 -->
-<div ng-controller="MarketplaceDetailsController as detailsCtrl" class="portlet-frame portlet-details-page" flex="100">
+<div ng-controller="MarketplaceDetailsController as detailsCtrl" class="portlet-details-page">
+  <frame-page app-title="Details: {{::portlet.title}}" app-icon="details">
     <md-card>
-        <div ng-if='loading' class="row details-header no-margin">
-            <loading-gif data-object='obj' data-empty='!loading'></loading-gif>
+      <div ng-if='loading' class="row details-header no-margin">
+        <loading-gif data-object='obj' data-empty='!loading'></loading-gif>
+      </div>
+      <div ng-if='error'>
+        <div class="alert alert-danger" role="alert" style='margin: 20px;'>
+          <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+          <span class="sr-only">Error:</span>
+          {{errorMessage}}
         </div>
-        <div ng-if='error'>
-            <div class="alert alert-danger" role="alert" style='margin: 20px;'>
-                <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-                <span class="sr-only">Error:</span>
-                {{errorMessage}}
+      </div>
+
+      <!-- DETAILS HEADER -->
+      <md-card-header tabindex="0" layout="row" class="no-margin" ng-if='!loading && !error'>
+        <md-card-avatar layout="column" layout-align="center center">
+          <portlet-icon class="md-headline"></portlet-icon>
+        </md-card-avatar>
+        <md-card-header-text layout="column" layout-align="center start">
+          <span class="md-headline" hide-xs>{{::portlet.title}}</span>
+          <span class="md-title" hide-gt-xs>{{::portlet.title}}</span>
+        </md-card-header-text>
+        <md-button ng-href="{{backURL}}" class="back-to-home md-primary"
+                   layout="row" layout-align="space-between center">
+          <i class="fa fa-arrow-circle-o-left" aria-hidden="true"></i>
+          <span hide-xs>Back to {{backText}}</span>
+        </md-button>
+      </md-card-header>
+
+      <!-- APP PREVIEW AND DETAILS -->
+      <div layout-xs="column" layout-gt-xs="row" class="no-margin" ng-if='!loading && !error'>
+
+        <!-- WIDGET PREVIEW -->
+        <div class="preview">
+          <div class="middle">
+            <widget fname="{{ portlet.fname }}"></widget>
+          </div>
+          <md-button class="md-raised md-primary fixed-width fname-{{::portlet.fname}}"
+                     ng-click="addToHome(portlet)"
+                     ng-if="portlet.canAdd && !portlet.hasInLayout"
+                     ng-disabled="portlet.hasInLayout">
+            Add to home
+          </md-button>
+        </div>
+
+        <!-- APP DETAILS -->
+        <md-content style="max-height: 800px;" flex>
+          <div layout="column">
+            <div class="desc-item">
+              <h3 tabindex="0" class="md-title">Description</h3>
+              <p tabindex="0" class="app-description">{{::portlet.description}}</p>
             </div>
-        </div>
+            <div class="desc-item">
+              <h3 tabindex="0" class="md-title">Ratings</h3>
+              <span ng-if="$storage.linkRatingsApi">
+                <span uib-rating ng-model="portlet.rating" read-only="true" class="rating"></span>
 
-        <!-- DETAILS HEADER -->
-        <md-card-header tabindex="0" layout="row" class="no-margin" ng-if='!loading && !error'>
-            <md-card-avatar layout="column" layout-align="center center">
-                <portlet-icon class="md-headline"></portlet-icon>
-            </md-card-avatar>
-            <md-card-header-text layout="column" layout-align="center start">
-                <span class="md-headline" hide-xs>{{::portlet.title}}</span>
-                <span class="md-title" hide-gt-xs>{{::portlet.title}}</span>
-            </md-card-header-text>
-            <md-button ng-href="{{backURL}}" class="back-to-home md-primary"
-                    layout="row" layout-align="space-between center">
-                <i class="fa fa-arrow-circle-o-left" aria-hidden="true"></i>
-                <span hide-xs>Back to {{backText}}</span>
-            </md-button>
-        </md-card-header>
-
-        <!-- APP PREVIEW AND DETAILS -->
-	    <div layout-xs="column" layout-gt-xs="row" class="no-margin"  ng-if='!loading && !error'>
-
-            <!-- WIDGET PREVIEW -->
-            <div class="preview">
-                <div class="middle">
-                    <widget fname="{{ portlet.fname }}"></widget>
-                </div>
-                <md-button class="md-raised md-primary fixed-width fname-{{::portlet.fname}}"
-                           ng-click="addToHome(portlet)"
-                           ng-if="portlet.canAdd && !portlet.hasInLayout"
-                           ng-disabled="portlet.hasInLayout">
-                    Add to home
-                </md-button>
+                ( <md-button ng-click="clickRatingReviewAdmin()">{{::portlet.userRated}} rating<span ng-if="portlet.userRated !== 1">s</span></md-button> )
+              </span>
+              <span ng-if="!$storage.linkRatingsApi">
+                <span uib-rating ng-model="portlet.rating" read-only="true" class="rating"></span>
+                ( {{::portlet.userRated}} rating<span ng-if="portlet.userRated !== 1">s</span> )
+              </span>
+              <br>
+              <rating-button ng-hide="GuestMode" portlet='portlet' button-text="Rate"
+                             button-classes="md-raised"></rating-button>
             </div>
+            <div class="desc-item"
+                 ng-if="portlet.relatedPortlets.length > 0">
+              <h3 tabindex="0" class="md-title">Related Apps</h3>
+              <ul>
+                <li ng-repeat="related in portlet.relatedPortlets"><a href="apps/details/{{ ::related.fname }}">{{
+                  ::related.title }}</a></li>
+              </ul>
+            </div>
+            <div class="desc-item" ng-if="portlet.marketplaceScreenshots.length != 0">
+              <h3 tabindex="0" class="md-title">Screenshots</h3>
+              <ul class="enlarge">
+                <li ng-repeat="screenshot in portlet.marketplaceScreenshots">
+                  <img ng-src="{{ ::screenshot.url }}" width="250px" alt="{{ ::screenshot.captions }}">
+                  <span>
+                    <img ng-src="{{ ::screenshot.url }}" alt="{{ ::screenshot.captions }}">
+                    <p ng-repeat="caption in screenshot.captions">{{ ::caption }}</p>
+                  </span>
+                </li>
+              </ul>
+            </div>
+            <div class="desc-item" ng-if="$storage.showKeywordsInMarketplace">
+              <h3 tabindex="0" class="md-title">Keywords</h3>
+              <ul>
+                <li ng-repeat="keyword in portlet.keywords | orderBy:'toLowerCase()'  track by $index"><a
+                  href='apps/search/{{ ::keyword }}'>{{ ::keyword }}</a></li>
+              </ul>
+            </div>
+          </div>
+        </md-content>
+      </div>
 
-            <!-- APP DETAILS -->
-            <md-content style="max-height: 800px;" flex>
-                <div layout="column">
-                    <div class="desc-item">
-                        <h3 tabindex="0" class="md-title">Description</h3>
-                        <p tabindex="0" class="app-description">{{::portlet.description}}</p>
-                    </div>
-                    <div class="desc-item">
-                        <h3 tabindex="0" class="md-title">Ratings</h3>
-                        <span ng-if="$storage.linkRatingsApi">
-                            <span uib-rating ng-model="portlet.rating" read-only="true" class="rating"></span>
-
-                            ( <md-button ng-click="clickRatingReviewAdmin()">{{::portlet.userRated}} rating<span ng-if="portlet.userRated !== 1">s</span></md-button> )
-
-                        </span>
-                        <span ng-if="!$storage.linkRatingsApi">
-                            <span uib-rating ng-model="portlet.rating" read-only="true" class="rating"></span>
-                            ( {{::portlet.userRated}} rating<span ng-if="portlet.userRated !== 1">s</span> )
-                        </span>
-                        <br>
-                        <rating-button ng-hide="GuestMode" portlet='portlet' button-text="Rate" button-classes="md-raised"></rating-button>
-                    </div>
-                    <div class="desc-item"
-                      ng-if="portlet.relatedPortlets.length > 0">
-                        <h3 tabindex="0" class="md-title">Related Apps</h3>
-                        <ul>
-                            <li ng-repeat="related in portlet.relatedPortlets"><a href="apps/details/{{ ::related.fname }}">{{ ::related.title }}</a></li>
-                        </ul>
-                    </div>
-                    <div class="desc-item" ng-if="portlet.marketplaceScreenshots.length != 0">
-                        <h3 tabindex="0" class="md-title">Screenshots</h3>
-                        <ul class="enlarge">
-                            <li ng-repeat="screenshot in portlet.marketplaceScreenshots">
-                                <img ng-src="{{ ::screenshot.url }}" width ="250px" alt="{{ ::screenshot.captions }}">
-                                <span>
-                                <img ng-src="{{ ::screenshot.url }}" alt="{{ ::screenshot.captions }}">
-                                <p ng-repeat="caption in screenshot.captions">{{ ::caption }}</p>
-                                </span>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="desc-item" ng-if="$storage.showKeywordsInMarketplace">
-                        <h3 tabindex="0" class="md-title">Keywords</h3>
-                        <ul>
-                            <li ng-repeat="keyword in portlet.keywords | orderBy:'toLowerCase()'  track by $index"><a href='apps/search/{{ ::keyword }}'>{{ ::keyword }}</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </md-content>
-	    </div>
-
-        <!-- FOOTER AND BACK TO LINK -->
-        <div class="portlet-footer" layout="row" layout-align="start center">
-            <md-button ng-href="{{backURL}}"><i class="fa fa-arrow-circle-o-left"></i> Back to {{backText}}</md-button>
-        </div>
-  </md-card>
+      <!-- FOOTER AND BACK TO LINK -->
+      <div class="portlet-footer" layout="row" layout-align="start center">
+        <md-button ng-href="{{backURL}}"><i class="fa fa-arrow-circle-o-left"></i> Back to {{backText}}</md-button>
+      </div>
+    </md-card>
+  </frame-page>
 </div>

--- a/web/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/web/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -18,75 +18,73 @@
     under the License.
 
 -->
-
-<div ng-controller="MarketplaceController as marketplaceCtrl" class="row portlet-frame marketplace col-xs-12 col-md-12 no-padding">
-  <app-header app-title="Browse {{NAMES.title}}"
-              app-icon="fa-home">
-  </app-header>
-  <div class="marketplace-body">
-    <div class="mp-header">
-      <md-input-container class="md-block browse-input">
-        <!-- Use floating label instead of placeholder -->
-        <label hide>What are you looking for?</label>
-        <md-icon><i class="fa fa-search"></i></md-icon>
-        <input type="text"
-               class="mp-search"
-               placeholder="What are you looking for?"
-               ng-model="searchText"
-               ng-change="searchResultLimit=20"
-               select-on-page-load
-               aria-label="search bar: enter the app you are looking for">
-      </md-input-container>
-    </div>
-
-    <div class="mp-tabs-container">
-      <div class="mp-prev-button" ng-click="slideTabs('left')">
-        <i class="fa fa-chevron-left"></i>
+<div ng-controller="MarketplaceController as marketplaceCtrl" class="marketplace">
+  <frame-page app-title="Browse {{NAMES.title}}" app-icon="home" app-show-add-to-home="false">
+    <div class="marketplace-body">
+      <div class="mp-header">
+        <md-input-container class="md-block browse-input">
+          <!-- Use floating label instead of placeholder -->
+          <label hide>What are you looking for?</label>
+          <md-icon><i class="fa fa-search"></i></md-icon>
+          <input type="text"
+                 class="mp-search"
+                 placeholder="What are you looking for?"
+                 ng-model="searchText"
+                 ng-change="searchResultLimit=20"
+                 select-on-page-load
+                 aria-label="search bar: enter the app you are looking for">
+        </md-input-container>
       </div>
-      <div class="mp-next-button" ng-click="slideTabs('right')">
-        <i class="fa fa-chevron-right"></i>
+
+      <div class="mp-tabs-container">
+        <div class="mp-prev-button" ng-click="slideTabs('left')">
+          <i class="fa fa-chevron-left"></i>
+        </div>
+        <div class="mp-next-button" ng-click="slideTabs('right')">
+          <i class="fa fa-chevron-right"></i>
+        </div>
+        <div class="mp-tabs-canvas">
+          <ul class="mp-tabs" ng-class="{true:'slide-right'}[tabsPosition === 'end']">
+            <li class="mp-tab md-ink-ripple" ng-click="selectFilter('popular','')"
+                ng-class="{true:'active'}[selectedFilter === 'popular']"
+                ng-style="selectedFilter === 'popular' && {color: primaryColorRgb}">
+              <span aria-label="Sort by popularity">Most Popular</span>
+              <div class="mp-tabs-slide" ng-style="{background: primaryColorRgb}"></div>
+            </li>
+            <li class="mp-tab md-ink-ripple" ng-click="selectFilter('az','')"
+                ng-class="{true: 'active'}[selectedFilter === 'az']"
+                ng-style="selectedFilter === 'az' && {color: primaryColorRgb}">
+              <span aria-label="Sort by alphabetical order">A-Z</span>
+              <div class="mp-tabs-slide" ng-style="{background: primaryColorRgb}"></div>
+            </li>
+          </ul>
+        </div>
       </div>
-      <div class="mp-tabs-canvas">
-        <ul class="mp-tabs" ng-class="{true:'slide-right'}[tabsPosition === 'end']">
-          <li class="mp-tab md-ink-ripple" ng-click="selectFilter('popular','')"
-              ng-class="{true:'active'}[selectedFilter === 'popular']"
-              ng-style="selectedFilter === 'popular' && {color: primaryColorRgb}">
-            <span aria-label="Sort by popularity">Most Popular</span>
-            <div class="mp-tabs-slide" ng-style="{background: primaryColorRgb}"></div>
-          </li>
-          <li class="mp-tab md-ink-ripple" ng-click="selectFilter('az','')"
-              ng-class="{true: 'active'}[selectedFilter === 'az']"
-              ng-style="selectedFilter === 'az' && {color: primaryColorRgb}">
-            <span aria-label="Sort by alphabetical order">A-Z</span>
-            <div class="mp-tabs-slide" ng-style="{background: primaryColorRgb}"></div>
-          </li>
-        </ul>
+
+      <md-chips ng-show="showCategories" class="show-categories"
+                ng-model="categories"
+                readonly="true"
+                md-removable="false">
+        <md-chip-template>
+          <a ng-click="selectFilter('category', $chip)" ng-class="{true: 'selected-category'}[categoryToShow === $chip]" aria-label="see apps in the {{ $chip }} category">{{ $chip }}</a>
+        </md-chip-template>
+      </md-chips>
+
+      <loading-gif data-object='portlets' layout="row" layout-align="center center"></loading-gif>
+
+      <div class="portlet-container"
+           ng-repeat="portlet in portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow | orderBy:sortParameter | limitTo:searchResultLimit"
+           ng-class="{portlet_hover: hover}"
+           ng-mouseenter="hover = true"
+           ng-mouseleave="hover = false"
+           ng-click="showDetails = !showDetails">
+        <marketplace-entry></marketplace-entry>
       </div>
+
+      <marketplace-load-more ng-show="portlets.length > 0 && (portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length > searchResultLimit"></marketplace-load-more>
+      <marketplace-no-results ng-show="portlets.length > 0 && (portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length == 0"></marketplace-no-results>
+
+      <!-- CHANGE INNER NAV TO MATERIAL TABS -->
     </div>
-
-    <md-chips ng-show="showCategories" class="show-categories"
-              ng-model="categories"
-              readonly="true"
-              md-removable="false">
-      <md-chip-template>
-        <a ng-click="selectFilter('category', $chip)" ng-class="{true: 'selected-category'}[categoryToShow === $chip]" aria-label="see apps in the {{ $chip }} category">{{ $chip }}</a>
-      </md-chip-template>
-    </md-chips>
-
-    <loading-gif data-object='portlets' layout="row" layout-align="center center"></loading-gif>
-
-    <div class="portlet-container"
-         ng-repeat="portlet in portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow | orderBy:sortParameter | limitTo:searchResultLimit"
-         ng-class="{portlet_hover: hover}"
-         ng-mouseenter="hover = true"
-         ng-mouseleave="hover = false"
-         ng-click="showDetails = !showDetails">
-      <marketplace-entry></marketplace-entry>
-    </div>
-
-    <marketplace-load-more ng-show="portlets.length > 0 && (portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length > searchResultLimit"></marketplace-load-more>
-    <marketplace-no-results ng-show="portlets.length > 0 && (portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length == 0"></marketplace-no-results>
-
-    <!-- CHANGE INNER NAV TO MATERIAL TABS -->
-  </div>
+  </frame-page>
 </div>

--- a/web/src/main/webapp/my-app/search/partials/search-results.html
+++ b/web/src/main/webapp/my-app/search/partials/search-results.html
@@ -18,95 +18,97 @@
     under the License.
 
 -->
-<md-content class="search-results">
-  <md-tabs md-dynamic-height md-border-bottom >
+<frame-page app-title="Search results" app-icon="search">
+  <md-content class="search-results">
+    <md-tabs md-dynamic-height md-border-bottom >
 
-    <!-- ALL RESULTS -->
-    <md-tab>
-      <md-tab-label>
-        All&nbsp;&nbsp;<span class="badge">{{ totalCount }}</span>
-      </md-tab-label>
-      <md-tab-body>
-        <md-content>
-          <!-- MyUW results -->
-          <div class="search-results-container">
-            <marketplace-results></marketplace-results>
-          </div>
+      <!-- ALL RESULTS -->
+      <md-tab>
+        <md-tab-label>
+          All&nbsp;&nbsp;<span class="badge">{{ totalCount }}</span>
+        </md-tab-label>
+        <md-tab-body>
+          <md-content>
+            <!-- MyUW results -->
+            <div class="search-results-container">
+              <marketplace-results></marketplace-results>
+            </div>
 
-          <!-- Wisc directory results-->
-          <div ng-show="directoryEnabled" class="search-results-container">
-            <directory-results></directory-results>
-          </div>
+            <!-- Wisc directory results-->
+            <div ng-show="directoryEnabled" class="search-results-container">
+              <directory-results></directory-results>
+            </div>
 
-          <!--Campus domain results-->
-          <div ng-show="googleSearchEnabled" class="search-results-container">
-            <campus-domain-results></campus-domain-results>
-          </div>
+            <!--Campus domain results-->
+            <div ng-show="googleSearchEnabled" class="search-results-container">
+              <campus-domain-results></campus-domain-results>
+            </div>
 
-          <!-- No search results found -->
-          <div id="no-results" class="search-results-container search-results" ng-show="totalCount === 0">
-            <p><strong>No matches.</strong></p>
-            <p>Suggestions:</p>
-            <p ng-if="kbSearchUrl">
-              Search the <a ng-href="{{kbSearchUrl}}{{searchText}}" target="_blank" rel="noopener noreferrer">KnowledgeBase</a>
-            </p>
-            <p ng-if="eventsSearchUrl">
-              Look for <a ng-href="{{eventsSearchUrl}}{{searchText}}" target="_blank" rel="noopener noreferrer">events</a>
-            </p>
-            <p ng-if="helpdeskUrl">
-              Get help from the <a ng-href="{{helpdeskUrl}}" target="_blank" rel="noopener noreferrer">Help Desk</a>
-            </p>
-            <p ng-if="feedbackUrl">
-              <a ng-href="{{feedbackUrl}}" target="_blank" rel="noopener noreferrer">Give feedback</a> on {{portal.theme.title}} search
-            </p>
-          </div>
-        </md-content>
-      </md-tab-body>
-    </md-tab>
+            <!-- No search results found -->
+            <div id="no-results" class="search-results-container search-results" ng-show="totalCount === 0">
+              <p><strong>No matches.</strong></p>
+              <p>Suggestions:</p>
+              <p ng-if="kbSearchUrl">
+                Search the <a ng-href="{{kbSearchUrl}}{{searchText}}" target="_blank" rel="noopener noreferrer">KnowledgeBase</a>
+              </p>
+              <p ng-if="eventsSearchUrl">
+                Look for <a ng-href="{{eventsSearchUrl}}{{searchText}}" target="_blank" rel="noopener noreferrer">events</a>
+              </p>
+              <p ng-if="helpdeskUrl">
+                Get help from the <a ng-href="{{helpdeskUrl}}" target="_blank" rel="noopener noreferrer">Help Desk</a>
+              </p>
+              <p ng-if="feedbackUrl">
+                <a ng-href="{{feedbackUrl}}" target="_blank" rel="noopener noreferrer">Give feedback</a> on {{portal.theme.title}} search
+              </p>
+            </div>
+          </md-content>
+        </md-tab-body>
+      </md-tab>
 
-    <!-- MyUW RESULTS ONLY -->
-    <md-tab ng-if="googleSearchEnabled || directoryEnabled">
-      <md-tab-label>
-        {{portal.theme.title}}&nbsp;&nbsp;<span class="badge">{{ myuwFilteredResults.length }}</span>
-      </md-tab-label>
-      <md-tab-body>
-        <md-content>
-          <!-- MyUW results -->
-          <div class="search-results-container">
-            <marketplace-results></marketplace-results>
-          </div>
-        </md-content>
-      </md-tab-body>
-    </md-tab>
+      <!-- MyUW RESULTS ONLY -->
+      <md-tab ng-if="googleSearchEnabled || directoryEnabled">
+        <md-tab-label>
+          {{portal.theme.title}}&nbsp;&nbsp;<span class="badge">{{ myuwFilteredResults.length }}</span>
+        </md-tab-label>
+        <md-tab-body>
+          <md-content>
+            <!-- MyUW results -->
+            <div class="search-results-container">
+              <marketplace-results></marketplace-results>
+            </div>
+          </md-content>
+        </md-tab-body>
+      </md-tab>
 
-    <!-- DIRECTORY RESULTS ONLY -->
-    <md-tab ng-if="directoryEnabled">
-      <md-tab-label>
-        Directory&nbsp;&nbsp;<span class="badge">{{ wiscDirectoryTooManyResults ? '25+' : wiscDirectoryResultCount }}</span>
-      </md-tab-label>
-      <md-tab-body>
-        <md-content>
-          <!-- Wisc directory results-->
-          <div ng-show="directoryEnabled" class="search-results-container">
-            <directory-results></directory-results>
-          </div>
-        </md-content>
-      </md-tab-body>
-    </md-tab>
+      <!-- DIRECTORY RESULTS ONLY -->
+      <md-tab ng-if="directoryEnabled">
+        <md-tab-label>
+          Directory&nbsp;&nbsp;<span class="badge">{{ wiscDirectoryTooManyResults ? '25+' : wiscDirectoryResultCount }}</span>
+        </md-tab-label>
+        <md-tab-body>
+          <md-content>
+            <!-- Wisc directory results-->
+            <div ng-show="directoryEnabled" class="search-results-container">
+              <directory-results></directory-results>
+            </div>
+          </md-content>
+        </md-tab-body>
+      </md-tab>
 
-    <!-- GOOGLE CUSTOM SEARCH RESULTS ONLY -->
-    <md-tab ng-if="googleSearchEnabled">
-      <md-tab-label>
-        {{domainResultsLabel}}&nbsp;&nbsp;<span class="badge">{{ googleResultsEstimatedCount }}</span>
-      </md-tab-label>
-      <md-tab-body>
-        <md-content>
-          <!--Campus domain results-->
-          <div ng-show="googleSearchEnabled" class="search-results-container">
-            <campus-domain-results></campus-domain-results>
-          </div>
-        </md-content>
-      </md-tab-body>
-    </md-tab>
-  </md-tabs>
-</md-content>
+      <!-- GOOGLE CUSTOM SEARCH RESULTS ONLY -->
+      <md-tab ng-if="googleSearchEnabled">
+        <md-tab-label>
+          {{domainResultsLabel}}&nbsp;&nbsp;<span class="badge">{{ googleResultsEstimatedCount }}</span>
+        </md-tab-label>
+        <md-tab-body>
+          <md-content>
+            <!--Campus domain results-->
+            <div ng-show="googleSearchEnabled" class="search-results-container">
+              <campus-domain-results></campus-domain-results>
+            </div>
+          </md-content>
+        </md-tab-body>
+      </md-tab>
+    </md-tabs>
+  </md-content>
+</frame-page>


### PR DESCRIPTION
This is to allow uportal-home to leverage the changes made in [uportal-app-framework#588](https://github.com/uPortal-Project/uportal-app-framework/pull/588)

**In this PR**:
- Wrapped all pages in `frame-page` to enable side navigation menu to work as intended
- Fixed some bonkers formatting in details page HTML

### Demo
![frame-page-demo](https://user-images.githubusercontent.com/5818702/32391477-386e835e-c0a0-11e7-9b4f-cbc4d70c6e7a.gif)


----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
