### PR TITLE
test(setup): configure to only run tests in uPortal-Home not in framework

### DIFF
--- a/web/src/main/webapp/karma.conf.js
+++ b/web/src/main/webapp/karma.conf.js
@@ -1,0 +1,80 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/* eslint-env node */
+module.exports = function(config) {
+    config.set({
+
+        basePath: './',
+
+        files: [
+          'test/main.js',
+          {pattern: './**', included: false},
+        ],
+
+        preprocessors: {
+          'my-app/**/*.js': 'coverage',
+        },
+
+        autoWatch: true,
+
+        frameworks: ['jasmine', 'requirejs'],
+
+        customLaunchers: {
+            FirefoxHeadless: {
+                base: 'Firefox',
+                flags: ['-headless'],
+            },
+        },
+
+        browsers: ['ChromeHeadless'], // or 'Chrome'
+
+        plugins: [
+            'karma-htmlfile-reporter',
+            'karma-chrome-launcher',
+            'karma-edge-launcher',
+            'karma-firefox-launcher',
+            'karma-ie-launcher',
+            'karma-safari-launcher',
+            'karma-jasmine',
+            'karma-requirejs',
+            'karma-coverage',
+            'karma-coveralls',
+        ],
+
+        reporters: ['dots', 'html', 'coverage', 'coveralls'],
+
+        htmlReporter: {
+          outputFile: 'test_out/units.html',
+        },
+
+        junitReporter: {
+            outputFile: 'test_out/unit.xml',
+            suite: 'unit',
+        },
+
+        coverageReporter: {
+          // lcov or lcovonly are required for generating lcov.info files
+          type: 'lcov',
+          dir: 'coverage/',
+        },
+
+        colors: true,
+
+    });
+};

--- a/web/src/main/webapp/test/main.js
+++ b/web/src/main/webapp/test/main.js
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/* eslint-env node */
+/* eslint-disable angular/window-service */
+// This will be run from the context of karma,
+// so using absolute path from karma's '/base'
+// eslint-disable-next-line requirejs/no-js-extension
+require(['/base/config.js'], function(config) {
+    // Add additional config for Karma testing
+    // Karma serves files under "/base", which
+    // is the basePath from the karma config file
+    config.baseUrl = '/base';
+    config.callback = window.__karma__.start;
+    config.deps = getAllTestFiles();
+    // eslint-disable-next-line angular/module-getter
+    require.config(config);
+
+    /**
+     * Find all test files by filename convention
+     * @return {Object} allTestFiles
+     */
+    function getAllTestFiles() {
+        var allTestFiles = [];
+        var TEST_REGEXP = /(spec|test)\.js$/i;
+        var EXCLUDE_REGEXP = /.*bower_components|node_modules|portal.*/;
+        var pathToModule = function(path) {
+            return path.replace(/^\/base\//, '').replace(/\.js$/, '');
+        };
+        Object.keys(window.__karma__.files).forEach(function(file) {
+            if (TEST_REGEXP.test(file)) {
+                if (!EXCLUDE_REGEXP.test(file)) {
+                    // Normalize paths to RequireJS module names.
+                    allTestFiles.push(pathToModule(file));
+                }
+            }
+        });
+        return allTestFiles;
+    }
+});


### PR DESCRIPTION
Currently the setup is to run tests in framework as well as app, this change sets it up so that it only runs the app tests by replacing files provided by the overlay.  This will resolve the failing tests here - https://github.com/uPortal-Project/uportal-home/pull/750

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
