### PR TITLE
ci(appveyor): resolve require js flakiness

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,11 @@ install:
   - mvn --version
   - node --version
   - npm --version
+
+  # Work around for "Error: EPERM: operation not permitted" from require js
+  # This can be removed when https://github.com/uPortal-Project/uportal-app-framework/issues/346 is resolved
+  - npm config set unsafe-perm=true
+
   - npm install
 build_script:
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V


### PR DESCRIPTION
Makes the unrelated "Error: EPERM: operation not permitted" errors going away.
This is a short term patch, https://github.com/uPortal-Project/uportal-app-framework/issues/346 is a better long term fix.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
