### PR TITLE
fix: use region-main in static and exclusive mode

### DIFF
--- a/web/src/main/webapp/my-app/layout/static/partials/static-content-exclusive.html
+++ b/web/src/main/webapp/my-app/layout/static/partials/static-content-exclusive.html
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<div ng-controller="ExclusiveContentController as exclusiveContentCtrl">
+<div ng-controller="ExclusiveContentController as exclusiveContentCtrl" class="region-main">
   <div ng-if="!loaded" layout="row" layout-align="center center" layout-padding>
     <loading-gif data-object="loaded"></loading-gif>
   </div>

--- a/web/src/main/webapp/my-app/layout/static/partials/static-content-max.html
+++ b/web/src/main/webapp/my-app/layout/static/partials/static-content-max.html
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-<div ng-controller="StaticContentController as staticContentCtrl">
+<div ng-controller="StaticContentController as staticContentCtrl" class="region-main">
   <div ng-if="!loaded" layout="row" layout-align="center center" layout-padding>
     <loading-gif data-object="loaded"></loading-gif>
   </div>


### PR DESCRIPTION
Addresses MUMUP-3231

before:
![image](https://user-images.githubusercontent.com/937952/34618240-bfd912fc-f203-11e7-9f76-1960039d10bd.png)


after:
![image](https://user-images.githubusercontent.com/937952/34618326-00ab3198-f204-11e7-9cc6-37e7e0276fc1.png)


----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
