### PR TITLE
fix: dropindex undefined when not moved

### DIFF
--- a/web/src/main/webapp/my-app/layout/controllers.js
+++ b/web/src/main/webapp/my-app/layout/controllers.js
@@ -301,7 +301,8 @@ define(['angular', 'jquery'], function(angular, $) {
         delay: 250,
         cursorAt: {top: 30, left: 30},
         stop: function(e, ui) {
-          if (ui.item.sortable.dropindex != ui.item.sortable.index) {
+          if (angular.isDefined(ui.item.sortable.dropindex)
+            && ui.item.sortable.dropindex !== ui.item.sortable.index) {
             var node = $scope.layout[ui.item.sortable.dropindex];
             $log.log('Change happened, logging move of ' + node.fname +
               ' from ' + ui.item.sortable.index +


### PR DESCRIPTION
dropindex seems to actually be undefined if you don't move it out of its place. This causes an error in the console. Test for undefined before testing for equal index.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
