### PR TITLE
fix: A-Z sort apps by title, not name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+* Alphabetically sort by `title` not `name` in app directory browse (#791)
 * Made `relatedPortlets` arrays empty in `entries.json` (#787)
 
 ### Removed

--- a/web/src/main/webapp/my-app/marketplace/controllers.js
+++ b/web/src/main/webapp/my-app/marketplace/controllers.js
@@ -248,10 +248,9 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
         if (currentPage === 'details') {
           // Empty string indicates no categories, show all portlets
           $scope.categoryToShow = '';
-          // Default filter is to sort by category for
-          // marketplaceDetails back to marketplace
+          // Default to filter by category on return back to app dir browse
           $scope.selectedFilter = 'category';
-          // To sort by category, angular will use title to filter
+          // When filtering by category, sort by title
           $scope.sortParameter = 'title';
           // Show category selection div by default
           $scope.showCategories = true;

--- a/web/src/main/webapp/my-app/marketplace/controllers.js
+++ b/web/src/main/webapp/my-app/marketplace/controllers.js
@@ -128,11 +128,11 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
         }
         if (filter === 'az') {
           $scope.selectedFilter = 'az';
-          $scope.sortParameter = 'name';
+          $scope.sortParameter = 'title';
         }
         if (filter === 'category') {
           $scope.selectedFilter = 'category';
-          $scope.sortParameter = 'name';
+          $scope.sortParameter = 'title';
           $scope.showCategories = true;
         }
 
@@ -251,8 +251,8 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
           // Default filter is to sort by category for
           // marketplaceDetails back to marketplace
           $scope.selectedFilter = 'category';
-          // To sort by category, angular will use name to filter
-          $scope.sortParameter = 'name';
+          // To sort by category, angular will use title to filter
+          $scope.sortParameter = 'title';
           // Show category selection div by default
           $scope.showCategories = true;
 


### PR DESCRIPTION
The app directory browse page currently can sort alphabetically, 

![alphabetical-mode-selected](https://user-images.githubusercontent.com/952283/37399290-4822473e-274f-11e8-9ed0-0a3a802fc4ac.png)

but prior to this changeset does so by [not-visible-to-users "name" (an administrative, internal label for content) rather than by the visible-to-users "title"](https://github.com/uPortal-Project/uportal-home/blob/master/docs/app-directory.md#title-and-name).

For most content these labels are the same, so it's an easy bug to overlook. Occasionally these labels are not the same, yielding a weird alphabetical sorting experience for users.

![not-actually-alphabetical-as-user-would-understand-it](https://user-images.githubusercontent.com/952283/37399303-5493290c-274f-11e8-86a6-15ac3a8ec486.png)

Incidentally encountered bug ( resolves #790 ) in trying to add mock data; seems a quick fix so taking a shot at it.

After:

![alpha-by-title](https://user-images.githubusercontent.com/952283/37399326-654b7772-274f-11e8-9ec3-5008ba57c7db.png)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
