### PR TITLE
fix: remove search total badge and controller support for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+* Removed defective (always zero) search results total badge (#797)
 * Alphabetically sort by `title` not `name` in app directory browse (#791)
 * Made `relatedPortlets` arrays empty in `entries.json` (#787)
 

--- a/web/src/main/webapp/my-app/search/controllers.js
+++ b/web/src/main/webapp/my-app/search/controllers.js
@@ -152,7 +152,6 @@ define([
         $scope.googleSearchEnabled = false;
         $scope.googleResultsEstimatedCount = 0;
         $scope.googleEmptyResults = false;
-        $scope.totalCount = 0;
         $scope.searchResultLimit = 20;
         $scope.showAll = $rootScope.GuestMode || false;
         base.setupSearchTerm();
@@ -166,22 +165,6 @@ define([
         }).catch(function() {
           $log.warn('Could not getPortlets');
         });
-        $scope.$watchGroup([
-            'googleResultsEstimatedCount',
-            'myuwFilteredResults.length',
-            'wiscDirectoryResultCount'],
-          function() {
-            $scope.totalCount = 0;
-            if ($scope.googleResultsEstimatedCount) {
-              $scope.totalCount+= parseInt($scope.googleResultsEstimatedCount);
-            }
-            if ($scope.myuwFilteredResults) {
-              $scope.totalCount+= parseInt($scope.myuwFilteredResults.length);
-            }
-            if ($scope.wiscDirectoryResultCount) {
-              $scope.totalCount+= parseInt($scope.wiscDirectoryResultCount);
-            }
-          });
       };
       init();
 

--- a/web/src/main/webapp/my-app/search/partials/search-results.html
+++ b/web/src/main/webapp/my-app/search/partials/search-results.html
@@ -25,7 +25,7 @@
       <!-- ALL RESULTS -->
       <md-tab>
         <md-tab-label>
-          All&nbsp;&nbsp;<span class="badge">{{ totalCount }}</span>
+          All</span>
         </md-tab-label>
         <md-tab-body>
           <md-content>


### PR DESCRIPTION
Was bugged to always total to zero.
Removing the feature 

+ "fixes the bug"
+ reduces bulk of code to maintain and
+ is (arguably) no less clear a user experience.

Before:

![zero-is-too-low-guess-again](https://user-images.githubusercontent.com/952283/37674873-d3cea38a-2c41-11e8-85dd-87ffccf5e42a.png)

After:

![there-is-no-total](https://user-images.githubusercontent.com/952283/37674887-dc8bf7fc-2c41-11e8-9557-8efe1b78c496.png)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
