### PR TITLE
fix: fail safe when portlet lacks title

### DIFF
--- a/web/src/main/webapp/my-app/marketplace/services.js
+++ b/web/src/main/webapp/my-app/marketplace/services.js
@@ -257,7 +257,9 @@ define(['angular', 'jquery'], function(angular, $) {
           var lowerSearchTerm = searchTerm.toLowerCase();
 
           // check title
-          if (portlet.title.toLowerCase().indexOf(lowerSearchTerm) !== -1) {
+          if (portlet
+              && portlet.title
+              && portlet.title.toLowerCase().indexOf(lowerSearchTerm) !== -1) {
             return true;
           }
 


### PR DESCRIPTION
In case where `portlet.title` undefined
don't consider that `portlet` a filter match on `title`
but also don't exception out the whole filtering attempt.

The app directory data should be good. This should never be a problem. But if the data is bad in this way, the consequence should be contained to the handling of that one bad record.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
