### PR TITLE
docs(icons): Prefer Material icons and deprecate Font Awesome icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Dependency upgrades
 * Updated app-framework to 9.0.1
 
-### Removed
-
-
 ## [8.0.0][] - 2018-03-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased][]
 
+### Deprecated
+
+* Support for Font Awesome icons (the `faIcon` parameter in `portlet-definition`
+  entity files) is formally deprecated, with Material icons (`mdIcon`) preferred
+  instead. Documentation is updated to reflect this preference and deprecation.
+  Support for Font Awesome icons will be removed in some future release.
+
 ## [8.1.1][] - 2018-03-30
 
 
@@ -34,12 +41,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 
-### Deprecated
-
-* Support for Font Awesome icons (the `faIcon` parameter in `portlet-definition`
-  entity files) is formally deprecated, with Material icons (`mdIcon`) preferred
-  instead. Documentation is updated to reflect this preference and deprecation.
-  Support for Font Awesome icons will be removed in some future release.
 
 ## [8.0.0][] - 2018-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 
+### Deprecated
+
+* Support for Font Awesome icons (the `faIcon` parameter in `portlet-definition`
+  entity files) is formally deprecated, with Material icons (`mdIcon`) preferred
+  instead. Documentation is updated to reflect this preference and deprecation.
+  Support for Font Awesome icons will be removed in some future release.
+
 ## [8.0.0][] - 2018-03-21
 
 ### Added

--- a/docs/app-directory.md
+++ b/docs/app-directory.md
@@ -86,11 +86,28 @@ Description text displays
 
 App directory entries optionally have an icon.
 
+##### Preferred: Material icons
+
+```xml
+<parameter>
+  <name>mdIcon</name>
+  <value>person</value>
+</parameter>
+```
+
+These can be any of the [Material icons][].
+
+##### Deprecated: Font Awesome icons
+
 ```xml
 <parameter><name>faIcon</name><value>fa-user</value></parameter>
 ```
 
-These can be any of the [Font Awesome icons][]. (uPortal-home intends to transition to using [Material icons][] instead in the near future.)
+These can be any of the [Font Awesome icons][].
+
+Support for Font Awesome icons is deprecated and will be removed in some future
+release, in the interest of continuing to standardize on and leverage Material
+Design.
 
 #### Categories
 


### PR DESCRIPTION
Since we prefer Material Icons, be really clear how configure `portlet-definition`s to use them.

Since we're pursuing Material Design, **formally deprecate Font Awesome icon support** in the hope of encouraging natural movement to the preferred icon vocabulary. **(This may be controversial.)**

(I'm not sure I knew how to make use of Material icons as app directory icons before seeing a colleague do it locally -- documenting the magic name of the `parameter` not least so I myself will come across this documentation next time I'm bootstrapping the icon for an app directory entry.)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
