### PR TITLE
docs: add impersonation.md documenting identity/attribute swapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
++ Documentation about `uPortal-home` specific considerations in implementing
+  uPortal's identity impersonation and attribute swapping features (#802)
 
 ### Changed
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,8 @@ Browse a directory of apps, sort them alphabetically or by rating, and filter th
 Search app directory entries, the web (with Google Custom Search integration), or a directory of people (with directory search integration).
 
 ## Integration with uPortal
+
++ [uPortal-home considerations in implementing uPortal impersonation features][]
 + [Silent Login Configuration](silent-login.md)
 
 ## Developing
@@ -59,3 +61,5 @@ Search app directory entries, the web (with Google Custom Search integration), o
 
 [uPortal]: http://jasig.github.io/uPortal/
 [uportal-user@]: https://groups.google.com/a/apereo.org/forum/#!forum/uportal-user
+
+[uPortal-home considerations in implementing uPortal impersonation features]: impersonation.md

--- a/docs/impersonation.md
+++ b/docs/impersonation.md
@@ -33,7 +33,13 @@ identity.
 uPortal-home may trigger other cache population. Widgets and messages
 (notifications and announcements) that rely upon portlet resource URLs for
 their JSON may cause portlets to cache data as the identity
-active when the widget was rendered.
+active when the widget was rendered or message was resolved.
+
+This may mean that users need to bookmark URLs that actuate the uPortal
+rendering pipeline rather than `uPortal-home` (e.g.
+`/uPortal/p/user-administration`) and initiate their uPortal sessions with those
+bookmarked URLs taking care to not visit any pages rendered by `uPortal-home`
+before activating the attribute swapping or impersonation features.
 
 ### Impersonation and attribute swapping may only apply selectively
 

--- a/docs/impersonation.md
+++ b/docs/impersonation.md
@@ -1,0 +1,44 @@
+# Attribute swapping and impersonation in uPortal-home
+
+## What is impersonation?
+
+Impersonation and attribute swapping are uPortal features enabling privileged
+users to pretend to be other users or to pretend to have some user attributes
+different from their "real" identity.
+
+Some uPortal implementations use these impersonation and attribute swapping
+features in some deployment tiers. Some don't.
+
+Where impersonation or attribute swapping are implemented, these features may be
+used to support e.g.
+
+* Development
+* Troubleshooting
+* Testing and quality assurance
+
+## What is special about uPortal-home and impersonation?
+
+### uPortal-home client-side caching
+
+One key to using impersonation or attribute swapping effectively is to adopt
+the pretended identity before caching content as the original identity.
+
+uPortal-home and its app framework cache information live in the page and in
+browser session storage. You may need to clear the relevant browser session
+storage and refresh the page to more fully experience the portal as the assumed
+identity.
+
+### Caches may populate sooner through message and widget side effects
+
+uPortal-home may trigger other cache population. Widgets and messages
+(notifications and announcements) that rely upon portlet resource URLs for
+their JSON may cause portlets to cache data as the identity
+active when the widget was rendered.
+
+### Impersonation and attribute swapping may only apply selectively
+
+Typically, impersonation and attribute swapping has effect only inside the
+uPortal monolith and not e.g. at the Shibboleth SP layer, and so will not apply
+to e.g. `rest-proxy`s or other JSON services that `uPortal-home` may call that
+get their identity from the context (e.g. headers set by `MOD_SHIB`) rather than
+from uPortal APIs.


### PR DESCRIPTION
I was confused by what turned out to be a cache population side effect of client-side message (notification) resolution. I'd realized the importance of removing widgets with side effects from the home page before impersonating, but I hadn't realized that `HRSPortlet` caches would populate anyway thanks to side effect of resolving the statements `resourceURL` to audience filter a notification.

Having had the insight that messages can now have these cache population side effects, added documentation to reflect.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
