### PR TITLE
feat: prompt confirmation/undo when removing widgets from home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   uPortal's identity impersonation and attribute swapping features (#802)
 
 ### Changed
-* Removing widget from home screen now prompts for confirmation (allowing UNDO action) before saving changes (#805)
+* Removing widget from home screen now displays a toast allowing UNDO action before saving changes (#805)
 
 ### Fixed
 * Fixed bug that sometimes caused the wrong widget to be removed from user's layout (#804)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ### Changed
-
+* Removing widget from home screen now prompts for confirmation (allowing UNDO action) before saving changes (#805)
 
 ### Fixed
-
+* Fixed bug that sometimes caused the wrong widget to be removed from user's layout (#804)
 
 ### Dependency upgrades
 

--- a/web/src/main/webapp/css/home.less
+++ b/web/src/main/webapp/css/home.less
@@ -161,19 +161,11 @@ div.table-cell {
   list-style-type: none;
   padding: 0 12px;
   margin: auto;
-  max-width: 1260px;
-
-  /* Grid Fallback */
+  max-width: @md;
   display: flex;
   flex-wrap: wrap;
-
-  /* Supports Grid */
-  /* stylelint-disable */
-  display: grid;
-  /* stylelint-enable */
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  grid-auto-rows: minmax(296px, 1fr);
-  grid-gap: 4px 8px;
+  flex-direction: row;
+  justify-content: flex-start;
 
   .dndPlaceholder {
     background: rgba(0, 0, 0, 0.12);
@@ -184,24 +176,53 @@ div.table-cell {
   }
 
   .widget-container:not(.dndDraggingSource) {
-    padding-right: 0;
-    padding-left: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin: 0;
-    flex: 1;
+    flex: 0 0 25%;
     overflow: hidden;
+    transition: flex 0.2s linear, transform 0.3s ease-out, opacity 0.3s linear;
+    padding: 8px;
+
+    &.ng-enter.ng-enter-active,
+    &.ng-leave {
+      opacity: 1;
+      flex: 0 0 25%;
+      transform: scaleX(1);
+
+      @media (max-width: @md) {
+        flex: 0 0 33%;
+      }
+
+      @media (max-width: @sm) {
+        flex: 0 0 50%;
+      }
+
+      @media (max-width: @widget-xs) {
+        flex: 0 0 100%;
+      }
+    }
+
+    &.ng-leave.ng-leave-active,
+    &.ng-enter {
+      opacity: 0;
+      flex: 0;
+      transform: scaleX(0);
+    }
 
     widget {
-      display: flex;
-      flex: 1;
-
       .widget-frame {
-        display: flex;
-        flex: 1;
         margin: 0;
       }
+    }
+
+    @media (max-width: @md) {
+      flex: 0 0 33%;
+    }
+
+    @media (max-width: @sm) {
+      flex: 0 0 50%;
+    }
+
+    @media (max-width: @widget-xs) {
+      flex: 0 0 100%;
     }
   }
 

--- a/web/src/main/webapp/css/home.less
+++ b/web/src/main/webapp/css/home.less
@@ -159,7 +159,7 @@ div.table-cell {
 
 .layout-list {
   list-style-type: none;
-  padding: 0;
+  padding: 0 12px;
   margin: auto;
   max-width: 1230px;
 

--- a/web/src/main/webapp/css/home.less
+++ b/web/src/main/webapp/css/home.less
@@ -161,7 +161,7 @@ div.table-cell {
   list-style-type: none;
   padding: 0 12px;
   margin: auto;
-  max-width: 1230px;
+  max-width: 1260px;
 
   /* Grid Fallback */
   display: flex;

--- a/web/src/main/webapp/css/my-app.less
+++ b/web/src/main/webapp/css/my-app.less
@@ -24,6 +24,7 @@
   @import "uw-portlet.less";
   @import "marketplace.less";
   @import "search-results.less";
+  @import "toast.less";
 }
 
 //Styles that need to be outside of .my-uw. e.g.: popups

--- a/web/src/main/webapp/css/toast.less
+++ b/web/src/main/webapp/css/toast.less
@@ -1,0 +1,68 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+md-toast {
+  &.toast__widget-removal {
+    .md-toast-content {
+      background-color: @white;
+      color: @black;
+      padding: 0;
+      align-items: flex-start;
+      max-height: 126px;
+      max-width: 320px;
+
+      &:before {
+        min-height: 0;
+      }
+
+      .toast__message {
+        padding: 16px;
+        width: 100%;
+
+        .toast__source {
+          font-size: 12px;
+        }
+
+        .toast__icon-container {
+          display: flex;
+          height: 44px;
+          width: 44px;
+          max-width: 44px;
+          background: #e5e5e5;
+          border-radius: 50%;
+          justify-content: center;
+          align-items: center;
+
+          .fa,
+          .material-icons {
+            font-size: 24px;
+          }
+        }
+      }
+
+      .toast__actions {
+        background-color: @grayscale2;
+        width: 100%;
+      }
+
+      .md-button {
+        min-width: 60px;
+      }
+    }
+  }
+}

--- a/web/src/main/webapp/css/toast.less
+++ b/web/src/main/webapp/css/toast.less
@@ -43,6 +43,7 @@ md-toast {
           height: 44px;
           width: 44px;
           max-width: 44px;
+          margin-right: 16px;
           background: #e5e5e5;
           border-radius: 50%;
           justify-content: center;
@@ -62,6 +63,22 @@ md-toast {
 
       .md-button {
         min-width: 60px;
+      }
+    }
+
+    @media (max-width: @sm) {
+      position: fixed;
+      padding: 16px;
+
+      .md-toast-content {
+        max-width: none;
+
+        .toast__actions {
+          .md-button {
+            margin-left: 0;
+            margin-right: 12px;
+          }
+        }
       }
     }
   }

--- a/web/src/main/webapp/css/toast.less
+++ b/web/src/main/webapp/css/toast.less
@@ -26,7 +26,7 @@ md-toast {
       max-height: 126px;
       max-width: 320px;
 
-      &:before {
+      &::before {
         min-height: 0;
       }
 

--- a/web/src/main/webapp/css/variables.less
+++ b/web/src/main/webapp/css/variables.less
@@ -24,9 +24,10 @@
 @home-view-1: 59;
 
 /* Media queries */
+@widget-xs: 680px;
 @xs: 600px;
 @sm: 960px;
-@md: 1280px;
+@md: 1260px;
 @lg: 1920px;
 
 // GRAYSCALE

--- a/web/src/main/webapp/my-app/layout/controllers.js
+++ b/web/src/main/webapp/my-app/layout/controllers.js
@@ -41,38 +41,65 @@ define(['angular', 'jquery'], function(angular, $) {
                                 $mdToast, $sessionStorage) {
       var vm = this;
       /**
-       * Show toast message confirming widget removal
+       * Remove widget from visible layout, then trigger confirmation toast
+       * before persisting the layout change
        * @param fname
        */
-      vm.removeWidget = function(fname) {
+      vm.removeWidget = function(title, fname) {
+        // Filter for fname match in layout
+        var result = $filter('filter')($scope.$parent.layout, fname);
+        var index = $scope.$parent.layout.indexOf(result[0]);
 
+        // Remove from layout
+        $scope.$parent.layout.splice(index, 1);
+
+        // Trigger confirmation toast
+        confirmWidgetRemoval(title, fname);
       };
 
-      var confirmWidgetRemoval = function() {
-        // layoutService.removeFromHome(fname).success(function() {
-        //   // Filter for fname match in layout
-        //   var result = $filter('filter')($scope.$parent.layout, fname);
-        //   var index = $scope.$parent.layout.indexOf(result[0]);
-        //
-        //   // Remove from layout
-        //   $scope.$apply($scope.$parent.layout.splice(index, 1));
-        //
-        //   // Clear marketplace flag
-        //   if ($sessionStorage.marketplace != null) {
-        //     // Filter for fname match in marketplace
-        //     var marketplaceEntries = $filter('filter')(
-        //       $sessionStorage.marketplace, result[0].fname
-        //     );
-        //     if (marketplaceEntries.length > 0) {
-        //       // Remove the entry flag
-        //       marketplaceEntries[0].hasInLayout = false;
-        //     }
-        //   }
-        // }).error(
-        //   function(request, text, error) {
-        //     alert('Issue deleting ' + fname +
-        //       ' from your list of favorites, try again later.');
-        //   });
+
+      var confirmWidgetRemoval = function(title, fname) {
+        $mdToast.show({
+          hideDelay: false,
+          parent: angular.element('.layout-list'),
+          position: 'top right',
+          scope: $scope,
+          templateUrl:
+            require.toUrl('my-app/layout/partials/toast-widget-removal.html'),
+          controller: function RemoveWidgetToastController(
+            $scope,
+            $sessionStorage,
+            layoutService
+          ) {
+            console.log(angular.element('.layout-list').scope());
+            console.log(angular.element('.toast__widget-removal').scope());
+            // If user clicked OK, persist change
+            // layoutService.removeFromHome(fname).success(function() {
+            //   // Filter for fname match in layout
+            //   var result = $filter('filter')($scope.$parent.layout, fname);
+            //   var index = $scope.$parent.layout.indexOf(result[0]);
+            //
+            //   // Remove from layout
+            //   $scope.$apply($scope.$parent.layout.splice(index, 1));
+            //
+            //   // Clear marketplace flag
+            //   if ($sessionStorage.marketplace != null) {
+            //     // Filter for fname match in marketplace
+            //     var marketplaceEntries = $filter('filter')(
+            //       $sessionStorage.marketplace, result[0].fname
+            //     );
+            //     if (marketplaceEntries.length > 0) {
+            //       // Remove the entry flag
+            //       marketplaceEntries[0].hasInLayout = false;
+            //     }
+            //   }
+            // }).error(
+            //   function(request, text, error) {
+            //     alert('Issue deleting ' + fname +
+            //       ' from your list of favorites, try again later.');
+            //   });
+          }
+        });
       };
     }])
 

--- a/web/src/main/webapp/my-app/layout/controllers.js
+++ b/web/src/main/webapp/my-app/layout/controllers.js
@@ -108,7 +108,11 @@ define(['angular', 'jquery'], function(angular, $) {
        * @param event {Object} The event object
        */
       $scope.moveWithKeyboard = function(widget, event) {
-        // get index independent of ng-repeat to avoid filter bugs
+        if ($scope.isToastDisplayed) {
+          return;
+        }
+
+        // Get index independent of ng-repeat to avoid filter bugs
         var currentIndex =
           findLayoutIndex($scope.layout, 'nodeId', widget.nodeId);
         var previousIndex = currentIndex - 1;

--- a/web/src/main/webapp/my-app/layout/controllers.js
+++ b/web/src/main/webapp/my-app/layout/controllers.js
@@ -346,11 +346,12 @@ define(['angular', 'jquery'], function(angular, $) {
       /**
        * Initialize expanded mode widget layout
        */
-      function init() {
+      vm.init = function() {
         if (angular.isUndefined($rootScope.layout) ||
         $rootScope.layout == null) {
           $rootScope.layout = [];
           $scope.layoutEmpty = false;
+
           // Get user's home layout
           layoutService.getLayout().then(function(data) {
             $rootScope.layout = data.layout;
@@ -363,8 +364,8 @@ define(['angular', 'jquery'], function(angular, $) {
             $log.warn('Could not getLayout');
           });
         }
-      }
+      };
 
-      init();
+      vm.init();
   }]);
 });

--- a/web/src/main/webapp/my-app/layout/controllers.js
+++ b/web/src/main/webapp/my-app/layout/controllers.js
@@ -198,7 +198,7 @@ define(['angular', 'jquery'], function(angular, $) {
         // Pass in widget for <widget-icon> directive
         // Pass in widget title for toast text display
         $mdToast.show({
-          hideDelay: false,
+          hideDelay: 2500,
           parent: angular.element(document).find('.wrapper__frame-page')[0],
           position: 'top right',
           locals: {

--- a/web/src/main/webapp/my-app/layout/controllers.js
+++ b/web/src/main/webapp/my-app/layout/controllers.js
@@ -181,14 +181,15 @@ define(['angular', 'jquery'], function(angular, $) {
        * @param data {Object} Information about the removed widget
        */
       var showConfirmationToast = function(data) {
+        var accentColor = '';
         if ($sessionStorage.portal.theme) {
           // theme already in session, use accent color from it
-          $scope.accentColorRgb =
+          accentColor =
             $mdColors.getThemeColor($sessionStorage.portal.theme.name
               + '-accent');
         } else {
           // theme not yet in session, use accent color from first theme
-          $scope.accentColorRgb =
+          accentColor =
             $mdColors.getThemeColor($rootScope.THEMES[0].name
               + '-accent');
         }
@@ -202,14 +203,16 @@ define(['angular', 'jquery'], function(angular, $) {
           position: 'top right',
           locals: {
             widget: data.removedWidget,
+            color: accentColor,
             removedTitle: data.removedWidget.title,
           },
           bindToController: true,
           templateUrl:
             require.toUrl('my-app/layout/partials/toast-widget-removal.html'),
-          controller: function RemoveToastController($scope, $mdToast,
-                                                     widget, removedTitle) {
+          controller: function RemoveToastController($scope, $mdToast, widget,
+                                                     color, removedTitle) {
             $scope.widget = widget;
+            $scope.accentColorRgb = color;
             $scope.removedTitle = removedTitle;
             /**
              * Resolve show() promise with 'undo'

--- a/web/src/main/webapp/my-app/layout/controllers.js
+++ b/web/src/main/webapp/my-app/layout/controllers.js
@@ -43,17 +43,15 @@ define(['angular', 'jquery'], function(angular, $) {
        * Capture information about removed widget, then
        * pass it up the chain to the layout scope in
        * WidgetController
-       * @param title {String} Human-readable widget title
-       * @param fname {String} Widget fname for matching in layout
+       * @param widget {Object} The widget being removed
        */
-      vm.removeWidget = function(title, fname) {
+      vm.removeWidget = function(widget) {
         // Match layout entry with fname
-        var result = $filter('filter')($scope.$parent.layout, fname);
+        var result = $filter('filter')($scope.$parent.layout, widget.fname);
         var index = $scope.$parent.layout.indexOf(result[0]);
         var data = {
-          removedTitle: title,
-          removedName: fname,
           removedIndex: index,
+          removedWidget: widget,
         };
         $scope.$emit('REMOVE_WIDGET', data);
       };
@@ -66,9 +64,9 @@ define(['angular', 'jquery'], function(angular, $) {
    */
   .controller('WidgetController',
   ['$controller', '$log', '$scope', '$rootScope', '$mdToast',
-    '$sessionStorage', '$filter', 'layoutService',
+    '$sessionStorage', '$filter', '$mdColors', 'layoutService',
     function($controller, $log, $scope, $rootScope, $mdToast,
-             $sessionStorage, $filter, layoutService) {
+             $sessionStorage, $filter, $mdColors, layoutService) {
       var vm = this;
       $scope.selectedNodeId = '';
       $scope.hideWidgetIndex = null;
@@ -179,14 +177,29 @@ define(['angular', 'jquery'], function(angular, $) {
        * @param data {Object} Information about the removed widget
        */
       var showConfirmationToast = function(data) {
-        $scope.removedTitle = data.removedTitle;
-        $scope.removedFname = data.removedName;
+        // Add widget to scope for <widget-icon> directive
+        $scope.widget = data.removedWidget;
+
+        $scope.removedTitle = data.removedWidget.title;
+        $scope.removedFname = data.removedWidget.fname;
         $scope.hideWidgetIndex = data.removedIndex;
+
+        if ($sessionStorage.portal.theme) {
+          // theme already in session, use primary color from it
+          $scope.accentColorRgb =
+            $mdColors.getThemeColor($sessionStorage.portal.theme.name
+              + '-accent');
+        } else {
+          // theme not yet in session, use primary color from zeroth theme
+          $scope.primaryColorRgb =
+            $mdColors.getThemeColor($rootScope.THEMES[0].name
+              + '-accent');
+        }
 
         // Configure and show the toast message
         $mdToast.show({
           hideDelay: false,
-          parent: angular.element(document).find('.layout-list')[0],
+          parent: angular.element(document).find('.wrapper__frame-page')[0],
           position: 'top right',
           scope: $scope,
           preserveScope: true,

--- a/web/src/main/webapp/my-app/layout/controllers.js
+++ b/web/src/main/webapp/my-app/layout/controllers.js
@@ -198,7 +198,7 @@ define(['angular', 'jquery'], function(angular, $) {
         // Pass in widget for <widget-icon> directive
         // Pass in widget title for toast text display
         $mdToast.show({
-          hideDelay: 2000,
+          hideDelay: false,
           parent: angular.element(document).find('.wrapper__frame-page')[0],
           position: 'top right',
           locals: {

--- a/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
+++ b/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
@@ -36,6 +36,7 @@
           tabindex="0"
           aria-label="{{ widget.title }}"
           keep-focus
+          ng-class="{ 'hidden' : $index === hideWidgetIndex }"
           node-id="{{ widget.nodeId }}"
           selected-node-id="{{ selectedNodeId }}"
           index="{{ $index }}"

--- a/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
+++ b/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
@@ -20,7 +20,7 @@
 -->
 <!-- COMPACT MODE -->
 <frame-page app-title="Home">
-  <div role="main" class="no-padding home__compact" ng-controller="WidgetController as widgetCtrl">
+  <div role="main" class="no-padding home__compact toast__anchor" ng-controller="WidgetController as widgetCtrl">
     <!-- HOME CONTROLS -->
     <home-controls></home-controls>
     <!-- Loading -->
@@ -30,7 +30,6 @@
     <!-- List View -->
     <ul dnd-list="layout"
         dnd-horizontal-list="true"
-        dnd-disable-if="isToastDisplayed"
         class="layout-list compact">
       <li class="dndPlaceholder no-padding widget-container"></li>
       <li class="no-padding widget-container"

--- a/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
+++ b/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
@@ -37,7 +37,6 @@
           tabindex="0"
           aria-label="{{ widget.title }}"
           keep-focus
-          ng-class="{ 'hidden' : $index === hideWidgetIndex }"
           node-id="{{ widget.nodeId }}"
           selected-node-id="{{ selectedNodeId }}"
           index="{{ $index }}"

--- a/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
+++ b/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
@@ -20,7 +20,7 @@
 -->
 <!-- COMPACT MODE -->
 <frame-page app-title="Home">
-  <div role="main" class="no-padding home__compact" ng-controller="LayoutController as layoutCtrl">
+  <div role="main" class="no-padding home__compact" ng-controller="WidgetController as widgetCtrl">
     <!-- HOME CONTROLS -->
     <home-controls></home-controls>
     <!-- Loading -->

--- a/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
+++ b/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
@@ -30,6 +30,7 @@
     <!-- List View -->
     <ul dnd-list="layout"
         dnd-horizontal-list="true"
+        dnd-disable-if="isToastDisplayed"
         class="layout-list compact">
       <li class="dndPlaceholder no-padding widget-container"></li>
       <li class="no-padding widget-container"

--- a/web/src/main/webapp/my-app/layout/partials/remove-button.html
+++ b/web/src/main/webapp/my-app/layout/partials/remove-button.html
@@ -19,8 +19,8 @@
 
 -->
 <md-button ng-controller="RemoveWidgetController as removeCtrl" class="widget-action widget-remove md-icon-button"
-           aria-label="remove {{ portlet.fname }} widget from your home screen"
-           ng-click="removeCtrl.removeWidget(portlet.title, portlet.fname)"
+           aria-label="remove {{ widget.fname }} widget from your home screen"
+           ng-click="removeCtrl.resolveOpenToasts();removeCtrl.removeWidget(widget.title, widget.fname)"
            ng-hide="GuestMode">
   <md-icon>close</md-icon>
 </md-button>

--- a/web/src/main/webapp/my-app/layout/partials/remove-button.html
+++ b/web/src/main/webapp/my-app/layout/partials/remove-button.html
@@ -20,7 +20,7 @@
 -->
 <md-button ng-controller="RemoveWidgetController as removeCtrl" class="widget-action widget-remove md-icon-button"
            aria-label="remove {{ portlet.fname }} widget from your home screen"
-           ng-click="removeCtrl.removePortlet(portlet.fname)"
+           ng-click="removeCtrl.removeWidget(portlet.fname)"
            ng-hide="GuestMode">
   <md-icon>close</md-icon>
 </md-button>

--- a/web/src/main/webapp/my-app/layout/partials/remove-button.html
+++ b/web/src/main/webapp/my-app/layout/partials/remove-button.html
@@ -20,7 +20,7 @@
 -->
 <md-button ng-controller="RemoveWidgetController as removeCtrl" class="widget-action widget-remove md-icon-button"
            aria-label="remove {{ portlet.fname }} widget from your home screen"
-           ng-click="removeCtrl.removeWidget(portlet.fname)"
+           ng-click="removeCtrl.removeWidget(portlet.title, portlet.fname)"
            ng-hide="GuestMode">
   <md-icon>close</md-icon>
 </md-button>

--- a/web/src/main/webapp/my-app/layout/partials/remove-button.html
+++ b/web/src/main/webapp/my-app/layout/partials/remove-button.html
@@ -20,7 +20,7 @@
 -->
 <md-button ng-controller="RemoveWidgetController as removeCtrl" class="widget-action widget-remove md-icon-button"
            aria-label="remove {{ widget.fname }} widget from your home screen"
-           ng-click="removeCtrl.removeWidget(widget.title, widget.fname)"
+           ng-click="removeCtrl.removeWidget(widget)"
            ng-hide="GuestMode">
   <md-icon>close</md-icon>
 </md-button>

--- a/web/src/main/webapp/my-app/layout/partials/toast-widget-removal.html
+++ b/web/src/main/webapp/my-app/layout/partials/toast-widget-removal.html
@@ -1,0 +1,11 @@
+<md-toast class="toast__widget-removal">
+  <div class="md-toast-content">
+    <span class="md-toast-text" flex>Removed {{ title }}</span>
+    <md-button class="md-highlight" ng-click="undoWidgetRemoval($event)">
+      Undo
+    </md-button>
+    <md-button ng-click="closeToast()">
+      OK
+    </md-button>
+  </div>
+</md-toast>

--- a/web/src/main/webapp/my-app/layout/partials/toast-widget-removal.html
+++ b/web/src/main/webapp/my-app/layout/partials/toast-widget-removal.html
@@ -22,7 +22,7 @@
   <div class="md-toast-content" layout="column">
     <div class="toast__message" layout="row" layout-align="space-between center">
       <div class="toast__text" layout="column" layout-align="center start" flex="80">
-        <span class="toast__source" ng-style="{ color: accentColorRgb }">Layout changed</span>
+        <span class="toast__source" ng-style="{ color: accentColorRgb }">Confirm change</span>
         <span>Removed {{ removedTitle }}</span>
       </div>
       <span class="toast__icon-container">

--- a/web/src/main/webapp/my-app/layout/partials/toast-widget-removal.html
+++ b/web/src/main/webapp/my-app/layout/partials/toast-widget-removal.html
@@ -33,9 +33,6 @@
       <md-button class="md-accent" ng-click="undoRemoveWidget($event)" aria-label="undo remove">
         Undo
       </md-button>
-      <md-button class="md-accent" ng-click="confirmRemoveWidget()" aria-label="confirm remove">
-        OK
-      </md-button>
     </div>
   </div>
 </md-toast>

--- a/web/src/main/webapp/my-app/layout/partials/toast-widget-removal.html
+++ b/web/src/main/webapp/my-app/layout/partials/toast-widget-removal.html
@@ -20,16 +20,16 @@
 -->
 <md-toast class="toast__widget-removal">
   <div class="md-toast-content" layout="column">
-    <div class="toast__message" layout="row" layout-align="space-between center">
-      <div class="toast__text" layout="column" layout-align="center start" flex="80">
-        <span class="toast__source" ng-style="{ color: accentColorRgb }">Undo change?</span>
-        <span>Removed {{ removedTitle }}</span>
-      </div>
+    <div class="toast__message" layout="row" layout-align="start center">
       <span class="toast__icon-container">
         <widget-icon></widget-icon>
       </span>
+      <div class="toast__text" layout="column" layout-align="center start">
+        <span class="toast__source" ng-style="{ color: accentColorRgb }">Undo change?</span>
+        <span>Removed {{ removedTitle }}</span>
+      </div>
     </div>
-    <div class="toast__actions" layout="row" layout-align="start center">
+    <div class="toast__actions" layout="row" layout-align="end center">
       <md-button class="md-accent" ng-click="undoRemoveWidget($event)" aria-label="undo remove">
         Undo
       </md-button>

--- a/web/src/main/webapp/my-app/layout/partials/toast-widget-removal.html
+++ b/web/src/main/webapp/my-app/layout/partials/toast-widget-removal.html
@@ -1,11 +1,41 @@
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <md-toast class="toast__widget-removal">
-  <div class="md-toast-content">
-    <span class="md-toast-text" flex>Removed {{ removedTitle }}</span>
-    <md-button class="md-highlight" ng-click="undoRemoveWidget($event)">
-      Undo
-    </md-button>
-    <md-button ng-click="confirmRemoveWidget()">
-      OK
-    </md-button>
+  <div class="md-toast-content" layout="column">
+    <div class="toast__message" layout="row" layout-align="space-between center">
+      <div class="toast__text" layout="column" layout-align="center start" flex="80">
+        <span class="toast__source" ng-style="{ color: accentColorRgb }">Layout changed</span>
+        <span>Removed {{ removedTitle }}</span>
+      </div>
+      <span class="toast__icon-container">
+        <widget-icon></widget-icon>
+      </span>
+    </div>
+    <div class="toast__actions" layout="row" layout-align="start center">
+      <md-button class="md-accent" ng-click="undoRemoveWidget($event)" aria-label="undo remove">
+        Undo
+      </md-button>
+      <md-button class="md-accent" ng-click="confirmRemoveWidget()" aria-label="confirm remove">
+        OK
+      </md-button>
+    </div>
   </div>
 </md-toast>

--- a/web/src/main/webapp/my-app/layout/partials/toast-widget-removal.html
+++ b/web/src/main/webapp/my-app/layout/partials/toast-widget-removal.html
@@ -1,10 +1,10 @@
 <md-toast class="toast__widget-removal">
   <div class="md-toast-content">
-    <span class="md-toast-text" flex>Removed {{ title }}</span>
-    <md-button class="md-highlight" ng-click="undoWidgetRemoval($event)">
+    <span class="md-toast-text" flex>Removed {{ removedTitle }}</span>
+    <md-button class="md-highlight" ng-click="undoRemoveWidget($event)">
       Undo
     </md-button>
-    <md-button ng-click="closeToast()">
+    <md-button ng-click="confirmRemoveWidget()">
       OK
     </md-button>
   </div>

--- a/web/src/main/webapp/my-app/layout/partials/toast-widget-removal.html
+++ b/web/src/main/webapp/my-app/layout/partials/toast-widget-removal.html
@@ -22,7 +22,7 @@
   <div class="md-toast-content" layout="column">
     <div class="toast__message" layout="row" layout-align="space-between center">
       <div class="toast__text" layout="column" layout-align="center start" flex="80">
-        <span class="toast__source" ng-style="{ color: accentColorRgb }">Confirm change</span>
+        <span class="toast__source" ng-style="{ color: accentColorRgb }">Undo change?</span>
         <span>Removed {{ removedTitle }}</span>
       </div>
       <span class="toast__icon-container">

--- a/web/src/main/webapp/my-app/layout/spec/layout_controller_spec.js
+++ b/web/src/main/webapp/my-app/layout/spec/layout_controller_spec.js
@@ -20,7 +20,7 @@
 /* eslint-env node, phantomjs, jasmine */
 /* global inject */
 define(['angular-mocks', 'portal', 'my-app'], function() {
-    describe('LayoutController', function() {
+    describe('WidgetController', function() {
       var scope;
       var controller;
       var $localStorage;
@@ -67,7 +67,7 @@ define(['angular-mocks', 'portal', 'my-app'], function() {
         loginSilentURL = _SERVICE_LOC_.loginSilentURL;
 
         sharedPortletService = {};
-        controller = $controller('LayoutController', {
+        controller = $controller('WidgetController', {
             '$localStorage': $localStorage,
             '$scope': scope,
             '$rootScope': rootScope,

--- a/web/src/main/webapp/my-app/layout/widget/partials/home-widget-view.html
+++ b/web/src/main/webapp/my-app/layout/widget/partials/home-widget-view.html
@@ -35,7 +35,6 @@
           tabindex="0"
           aria-label="{{ widget.title }}"
           keep-focus
-          ng-class="{ 'hidden' : $index === hideWidgetIndex }"
           node-id="{{ widget.nodeId }}"
           selected-node-id="{{ selectedNodeId }}"
           index="{{ $index }}"

--- a/web/src/main/webapp/my-app/layout/widget/partials/home-widget-view.html
+++ b/web/src/main/webapp/my-app/layout/widget/partials/home-widget-view.html
@@ -20,7 +20,7 @@
 -->
 <!-- HOME-WIDGET-VIEW -->
 <frame-page app-title="Home">
-  <div role="main" class="home__expanded" ng-controller="WidgetController as widgetCtrl">
+  <div role="main" class="home__expanded toast__anchor" ng-controller="WidgetController as widgetCtrl">
     <!-- HOME CONTROLS -->
     <home-controls></home-controls>
     <!-- Loading -->
@@ -28,7 +28,6 @@
     <!-- Widget View -->
     <ul dnd-list="layout"
         dnd-horizontal-list="true"
-        dnd-disable-if="isToastDisplayed === true"
         class="layout-list">
       <example-widgets ng-if="$storage.exampleWidgets"></example-widgets>
       <li class="no-padding widget-container"

--- a/web/src/main/webapp/my-app/layout/widget/partials/home-widget-view.html
+++ b/web/src/main/webapp/my-app/layout/widget/partials/home-widget-view.html
@@ -34,6 +34,7 @@
           tabindex="0"
           aria-label="{{ widget.title }}"
           keep-focus
+          ng-class="{ 'hidden' : $index === hideWidgetIndex }"
           node-id="{{ widget.nodeId }}"
           selected-node-id="{{ selectedNodeId }}"
           index="{{ $index }}"

--- a/web/src/main/webapp/my-app/layout/widget/partials/home-widget-view.html
+++ b/web/src/main/webapp/my-app/layout/widget/partials/home-widget-view.html
@@ -28,6 +28,7 @@
     <!-- Widget View -->
     <ul dnd-list="layout"
         dnd-horizontal-list="true"
+        dnd-disable-if="isToastDisplayed === true"
         class="layout-list">
       <example-widgets ng-if="$storage.exampleWidgets"></example-widgets>
       <li class="no-padding widget-container"


### PR DESCRIPTION
[MUMUP-3095](https://jira.doit.wisc.edu/jira/browse/MUMUP-3095): "As a person who just deleted an item from my MyUW homepage, I'd like acknowledgement that I did this and the opportunity to undo it, so I can understand what I did and recover if it's not what I really want."

**In this PR:**
- Removing a widget can be undone via a toast message
    - Toast resolves automatically after 3 seconds
    - If user clicks "Undo" before resolution, the widget is added back to the layout
- If user deletes another widget before the first toast has resolved, it will automatically resolve it and show a new toast
- On large screens, toast appears in top right of application space
- On small screens, toast appears at bottom of screen (per Material specs)
- Removed unnecessary `LayoutController`. Expanded and compact modes now share the same layout controller (`WidgetController`).
- Removed CSS-grid layout in favor of more widely supported flex box
- Updated existing layout controller unit test to test widget controller instead
- Animate widget removal/addition/move


**A note about the custom toast message:** The toast attempts to follow pattern guidelines for [Material Notifications](https://material.io/guidelines/patterns/notifications.html), so it is a custom version of Angular Material's "Toast" directive. All the customizations were made in one commit [9f3b253](https://github.com/uPortal-Project/uportal-home/commit/9f3b2534e5a78cae164faf83d5d42e8fefc1b7f9) to make reverting this work easier, if necessary/desired.

### Demos
![confirm-remove-lg](https://user-images.githubusercontent.com/5818702/37987256-4bd1363c-31c3-11e8-9385-6138762afe43.gif)
![confirm-remove-sm](https://user-images.githubusercontent.com/5818702/37987258-4be0a4d2-31c3-11e8-853b-ff44740143df.gif)



----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
