### PR TITLE
fix: tweak snackbars per material guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [8.1.1][] - 2018-03-30
 
+
+### Changes
+* Tweaked "Undo" action toasts to better conform to []material guidelines](https://material.io/guidelines/components/snackbars-toasts.html#) (#808)
+
 ### Dependency upgrades
 * Updated app-framework to 9.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ### Changes
-* Tweaked "Undo" action toasts to better conform to []material guidelines](https://material.io/guidelines/components/snackbars-toasts.html#) (#808)
+* Tweaked "Undo" action toasts to better conform to [material guidelines](https://material.io/guidelines/components/snackbars-toasts.html#) (#808)
 
 ### Dependency upgrades
 * Updated app-framework to 9.0.2

--- a/web/src/main/webapp/css/toast.less
+++ b/web/src/main/webapp/css/toast.less
@@ -18,58 +18,19 @@
  */
 md-toast {
   &.toast__widget-removal {
+    position: fixed;
+    padding: 16px;
+
     .md-toast-content {
-      background-color: @white;
-      color: @black;
-      padding: 0;
-      align-items: flex-start;
-      max-height: 126px;
-      max-width: 320px;
+      background: @grayscale9;
+      color: @white;
 
-      &::before {
-        min-height: 0;
-      }
-
-      .toast__message {
-        padding: 16px;
-        width: 100%;
-
-        .toast__source {
-          font-size: 12px;
-        }
-
-        .toast__icon-container {
-          display: flex;
-          height: 44px;
-          width: 44px;
-          max-width: 44px;
-          margin-right: 16px;
-          background: #e5e5e5;
-          border-radius: 50%;
-          justify-content: center;
-          align-items: center;
-
-          .fa,
-          .material-icons {
-            font-size: 24px;
-          }
-        }
-      }
-
-      .toast__actions {
-        background-color: @grayscale2;
-        width: 100%;
-      }
-
-      .md-button {
-        min-width: 60px;
+      @media (min-width: @sm) {
+        min-width: 350px;
       }
     }
 
     @media (max-width: @sm) {
-      position: fixed;
-      padding: 16px;
-
       .md-toast-content {
         max-width: none;
 

--- a/web/src/main/webapp/my-app/layout/controllers.js
+++ b/web/src/main/webapp/my-app/layout/controllers.js
@@ -195,23 +195,20 @@ define(['angular', 'jquery'], function(angular, $) {
         }
 
         // Configure and show the toast message
-        // Pass in widget for <widget-icon> directive
         // Pass in widget title for toast text display
         $mdToast.show({
-          hideDelay: 2500,
+          hideDelay: 3000,
           parent: angular.element(document).find('.wrapper__frame-page')[0],
-          position: 'top right',
+          position: 'bottom right',
           locals: {
-            widget: data.removedWidget,
             color: accentColor,
             removedTitle: data.removedWidget.title,
           },
           bindToController: true,
           templateUrl:
             require.toUrl('my-app/layout/partials/toast-widget-removal.html'),
-          controller: function RemoveToastController($scope, $mdToast, widget,
+          controller: function RemoveToastController($scope, $mdToast,
                                                      color, removedTitle) {
-            $scope.widget = widget;
             $scope.accentColorRgb = color;
             $scope.removedTitle = removedTitle;
             /**

--- a/web/src/main/webapp/my-app/layout/controllers.js
+++ b/web/src/main/webapp/my-app/layout/controllers.js
@@ -197,7 +197,7 @@ define(['angular', 'jquery'], function(angular, $) {
         // Configure and show the toast message
         // Pass in widget title for toast text display
         $mdToast.show({
-          hideDelay: 3000,
+          hideDelay: 4000,
           parent: angular.element(document).find('.wrapper__frame-page')[0],
           position: 'bottom right',
           locals: {

--- a/web/src/main/webapp/my-app/layout/partials/toast-widget-removal.html
+++ b/web/src/main/webapp/my-app/layout/partials/toast-widget-removal.html
@@ -19,20 +19,10 @@
 
 -->
 <md-toast class="toast__widget-removal">
-  <div class="md-toast-content" layout="column">
-    <div class="toast__message" layout="row" layout-align="start center">
-      <span class="toast__icon-container">
-        <widget-icon></widget-icon>
-      </span>
-      <div class="toast__text" layout="column" layout-align="center start">
-        <span class="toast__source" ng-style="{ color: accentColorRgb }">Undo change?</span>
-        <span>Removed {{ removedTitle }}</span>
-      </div>
-    </div>
-    <div class="toast__actions" layout="row" layout-align="end center">
-      <md-button class="md-accent" ng-click="undoRemoveWidget($event)" aria-label="undo remove">
-        Undo
-      </md-button>
-    </div>
+  <div class="md-toast-content" layout="row">
+    <span flex>Removed {{ removedTitle }}</span>
+    <md-button class="md-accent md-raised" ng-click="undoRemoveWidget($event)" aria-label="undo remove">
+      Undo
+    </md-button>
   </div>
 </md-toast>


### PR DESCRIPTION
[MUMMNG-4155](https://jira.doit.wisc.edu/jira/browse/MUMMNG-4155): "As a user who recently deleted a widget from my layout, I would like the opportunity to undo my action before the snackbar disappears, so that I may undo a delete if I want."

[Material guidelines for snackbars & toasts](https://material.io/guidelines/components/snackbars-toasts.html#)

**In this PR**:
- Increased time before auto-hide
- Removed customizations that made snackbars look like notifications
- No longer show widget icons in snackbar message
- Snackbar always appears fixed to bottom of viewport (so it's always visible)

### Demo/screenshot
![confirm-remove](https://user-images.githubusercontent.com/5818702/38512636-5ca169fe-3bf1-11e8-9c85-8086bfd8cd2c.gif)
![screen shot 2018-04-09 at 12 24 32 pm](https://user-images.githubusercontent.com/5818702/38512637-5cb0c890-3bf1-11e8-9df1-a7f9ed2d36a1.png)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
