### PR TITLE
fix: app search results by title first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 * Removing widget from home screen now displays a toast allowing UNDO action before saving changes (#805)
+* App search results now order by matching titles first, then matching descriptions/keywords (#809)
 
 ### Fixed
 * Fixed bug that sometimes caused the wrong widget to be removed from user's layout (#804)

--- a/web/src/main/webapp/css/search-results.less
+++ b/web/src/main/webapp/css/search-results.less
@@ -19,6 +19,14 @@
 .search-results {
   padding: 3px 0 0;
 
+  .search-term {
+    padding: 0 18px;
+
+    > span {
+      font-weight: 600;
+    }
+  }
+
   .no-result {
     padding: 10px 16px;
   }

--- a/web/src/main/webapp/my-app/search/partials/marketplace-results.html
+++ b/web/src/main/webapp/my-app/search/partials/marketplace-results.html
@@ -20,25 +20,25 @@
 -->
 <h4 class="md-subhead">
   <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
-  {{portal.theme.title}}
+  {{ portal.theme.title }}
 </h4>
 <div layout="row" layout-align="center center">
-  <loading-gif data-object='myuwResults'></loading-gif>
+  <loading-gif data-object="filteredApps"></loading-gif>
 </div>
-<div ng-show="myuwResults.length != 0 && myuwFilteredResults.length == 0" class='no-result'>
-  No {{portal.theme.title}} results. <a href="apps">Try browsing instead?</a>
+<div ng-show="myuwResults.length != 0 && filteredApps.length == 0" class="no-result">
+  No {{ portal.theme.title }} results. <a href="apps">See all apps?</a>
 </div>
-<div class="result" ng-repeat="portlet in myuwFilteredResults = (myuwResults | filter:searchTermFilter | showApplicable:showAll | orderBy:sortParameter | limitTo:searchResultLimit)">
-  <h4><a ng-href="{{getLaunchURL(portlet)}}" target="{{::portlet.target}}" rel="{{::portlet.target | targetToRel}}">{{ portlet.title }}</a> <small ng-if='GuestMode && !portlet.canAdd'>(login to use)</small></h4>
-  <p>{{ portlet.description }}</p>
+<div class="result" ng-repeat="app in filteredApps | showApplicable:showAll | limitTo:searchResultLimit">
+  <h4><a ng-href="{{ getLaunchURL(app) }}" target="{{::app.target}}" rel="{{::app.target | targetToRel}}">{{ app.title }}</a> <small ng-if="GuestMode && !app.canAdd">(login to use)</small></h4>
+  <p>{{ app.description }}</p>
   <p>
-    <md-button ng-click="addToHome(portlet)"
-               ng-if="portlet.canAdd && !portlet.hasInLayout && !GuestMode"
-               class="md-primary add" aria-label="add {{ portlet.title }} to home">
+    <md-button ng-click="addToHome(app)"
+               ng-if="app.canAdd && !app.hasInLayout && !GuestMode"
+               class="md-primary add" aria-label="add {{ app.title }} to home">
       <i class="fa fa-plus"></i> Add to home
     </md-button>
-    <span ng-if="portlet.canAdd && portlet.hasInLayout && !GuestMode" class="added"><i class="fa fa-check"></i> Added to home</span>
-    <md-button class="md-default" aria-label="See more about {{portlet.title}}" ng-click='navToDetails(portlet, "Search")'>Details</md-button>
-    <span><span uib-rating ng-if="portlet.userRating" ng-model="portlet.rating" read-only="true" class="rating"></span></span>
+    <span ng-if="app.canAdd && app.hasInLayout && !GuestMode" class="added"><i class="fa fa-check"></i> Added to home</span>
+    <md-button class="md-default" aria-label="See more about {{ app.title }}" ng-click="navToDetails(app, 'Search')">Details</md-button>
+    <span><span uib-rating ng-if="app.userRating" ng-model="app.rating" read-only="true" class="rating"></span></span>
   </p>
 </div>

--- a/web/src/main/webapp/my-app/search/partials/search-results.html
+++ b/web/src/main/webapp/my-app/search/partials/search-results.html
@@ -20,6 +20,7 @@
 -->
 <frame-page app-title="Search results" app-icon="search" page-title="Search results" white-background="true">
   <md-content class="search-results">
+    <p class="search-term">Showing results for <span>"{{ searchTerm }}"</span></p>
     <md-tabs md-dynamic-height md-border-bottom >
 
       <!-- ALL RESULTS -->
@@ -68,7 +69,7 @@
       <!-- MyUW RESULTS ONLY -->
       <md-tab ng-if="googleSearchEnabled || directoryEnabled">
         <md-tab-label>
-          {{portal.theme.title}}&nbsp;&nbsp;<span class="badge">{{ myuwFilteredResults.length }}</span>
+          {{ portal.theme.title }}&nbsp;&nbsp;<span class="badge">{{ filteredApps.length }}</span>
         </md-tab-label>
         <md-tab-body>
           <md-content>


### PR DESCRIPTION
[MUMMNG-4156](https://jira.doit.wisc.edu/jira/browse/MUMMNG-4156): "As a MyUW user trying to find the enroll app ("Course Search and Enroll"), I want it to be the top result when I search for "enroll" or "enrollment", so that I'm not under the impression that it's not a thing."

**In this PR**:
- Order app search results by matching titles, then matching keywords/descriptions
- Removed alphabetical/popularity ordering (unused)
- Added a bit of text that shows the search term being used

![screen shot 2018-04-11 at 11 45 12 am](https://user-images.githubusercontent.com/5818702/38631746-3f374a92-3d80-11e8-9168-e7e82092611c.png)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
