### PR TITLE
fix: better support rapid widget removal 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased][]
 
 ### Deprecated
-
-* Support for Font Awesome icons (the `faIcon` parameter in `portlet-definition`
-  entity files) is formally deprecated, with Material icons (`mdIcon`) preferred
-  instead. Documentation is updated to reflect this preference and deprecation.
-  Support for Font Awesome icons will be removed in some future release.
+* Support for Font Awesome icons (the `faIcon` parameter in `portlet-definition` entity files) is formally deprecated, 
+with Material icons (`mdIcon`) preferred instead. Documentation is updated to reflect this preference and deprecation. 
+Support for Font Awesome icons will be removed in some future release.
+  
+### Changed
+* Adjusted "Undo" action toasts to better support rapid widget deletion (#812)
 
 ## [8.1.1][] - 2018-03-30
 

--- a/web/src/main/webapp/my-app/layout/controllers.js
+++ b/web/src/main/webapp/my-app/layout/controllers.js
@@ -194,6 +194,7 @@ define(['angular', 'jquery'], function(angular, $) {
           // Track the widget fname for removal upon
           // toast timeout
           $scope.widgetsToRemove.push(data.removedWidget.fname);
+          console.log($scope.widgetsToRemove);
 
           // Dismiss any open toasts (success), then show new one
           // eslint-disable-next-line promise/always-return
@@ -257,7 +258,7 @@ define(['angular', 'jquery'], function(angular, $) {
             // Add the removed widget back to the layout
             $scope.layout.splice(data.removedIndex, 0, data.removedWidget);
 
-            // Remove the widget's fname from the tracking array
+            // Delete the last fname added to the removal array
             $scope.widgetsToRemove.pop();
           } else {
             // Save deletion of any widgets in the tracking array

--- a/web/src/main/webapp/my-app/layout/controllers.js
+++ b/web/src/main/webapp/my-app/layout/controllers.js
@@ -69,6 +69,7 @@ define(['angular', 'jquery'], function(angular, $) {
              $sessionStorage, $filter, $mdColors, layoutService) {
       var vm = this;
       $scope.selectedNodeId = '';
+      $scope.widgetsToRemove = [];
 
       /**
        * Set the selected widget in scope to track focus
@@ -190,6 +191,10 @@ define(['angular', 'jquery'], function(angular, $) {
           // Remove the widget from layout in scope
           $scope.layout.splice(data.removedIndex, 1);
 
+          // Track the widget fname for removal upon
+          // toast timeout
+          $scope.widgetsToRemove.push(data.removedWidget.fname);
+
           // Dismiss any open toasts (success), then show new one
           // eslint-disable-next-line promise/always-return
           $mdToast.hide().then(function() {
@@ -251,9 +256,17 @@ define(['angular', 'jquery'], function(angular, $) {
           if (response === 'undo') {
             // Add the removed widget back to the layout
             $scope.layout.splice(data.removedIndex, 0, data.removedWidget);
+
+            // Remove the widget's fname from the tracking array
+            $scope.widgetsToRemove.pop();
           } else {
-            // Persist changes
-            saveLayoutRemoval(data.removedWidget.fname, data.removedIndex);
+            // Save deletion of any widgets in the tracking array
+            for (var i = 0; i < $scope.widgetsToRemove.length; i++) {
+              var fname = $scope.widgetsToRemove[i];
+              saveLayoutRemoval(fname);
+              // Remove saved deletions from tracking array
+              $scope.widgetsToRemove.splice(i, 1);
+            }
           }
           return response;
         })
@@ -266,17 +279,12 @@ define(['angular', 'jquery'], function(angular, $) {
        * Call layout service to save the removal of the widget from the user's
        * home layout.
        * @param fname {String} The fname of the removed widget
-       * @param index {Number} The index of the removed widget in the layout
        */
-      var saveLayoutRemoval = function(fname, index) {
+      var saveLayoutRemoval = function(fname) {
         // Call layout service to persist change
         layoutService.removeFromHome(fname)
           .success(function() {
-            // Remove from layout in scope
-            // $scope.layout.splice(index, 1);
-
-            // Reset CSS hiding
-            $scope.hideWidgetIndex = null;
+            console.log('service removed ' + fname + ' from home layout');
 
             // Clear marketplace flag
             if ($sessionStorage.marketplace != null) {

--- a/web/src/main/webapp/my-app/layout/controllers.js
+++ b/web/src/main/webapp/my-app/layout/controllers.js
@@ -194,7 +194,6 @@ define(['angular', 'jquery'], function(angular, $) {
           // Track the widget fname for removal upon
           // toast timeout
           $scope.widgetsToRemove.push(data.removedWidget.fname);
-          console.log($scope.widgetsToRemove);
 
           // Dismiss any open toasts (success), then show new one
           // eslint-disable-next-line promise/always-return
@@ -285,8 +284,6 @@ define(['angular', 'jquery'], function(angular, $) {
         // Call layout service to persist change
         layoutService.removeFromHome(fname)
           .success(function() {
-            console.log('service removed ' + fname + ' from home layout');
-
             // Clear marketplace flag
             if ($sessionStorage.marketplace != null) {
               // Filter for fname match in marketplace


### PR DESCRIPTION
[MUMUP-3332](https://jira.doit.wisc.edu/jira/browse/MUMUP-3332): "As a MyUW user, I would like to be able to delete widgets quickly without waiting for the undo snackbar to elapse so that I can declutter my homepage with alacrity and decisiveness."

**In this PR**:
- Track widgets removed by user outside of toast promise cycle and follow through on removal whenever a toast's promise is resolved
- Clean up some unused code

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
