### PR TITLE
style(changelog): blank lines around headings, wrap at 80 char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased][]
 
 ### Deprecated
-* Support for Font Awesome icons (the `faIcon` parameter in `portlet-definition` entity files) is formally deprecated, 
-with Material icons (`mdIcon`) preferred instead. Documentation is updated to reflect this preference and deprecation. 
+
+* Support for Font Awesome icons (the `faIcon` parameter in `portlet-definition` entity files) is formally deprecated,
+with Material icons (`mdIcon`) preferred instead. Documentation is updated to reflect this preference and deprecation.
 Support for Font Awesome icons will be removed in some future release.
-  
+
 ### Changed
+
 * Adjusted "Undo" action toasts to better support rapid widget deletion (#812)
 
 ## [8.1.1][] - 2018-03-30
 
 
 ### Changes
+
 * Tweaked "Undo" action toasts to better conform to [material guidelines](https://material.io/guidelines/components/snackbars-toasts.html#) (#808)
 
 ### Dependency upgrades
+
 * Updated app-framework to 9.0.2
 
 ## [8.1.0][] - 2018-03-30
@@ -32,33 +36,40 @@ Support for Font Awesome icons will be removed in some future release.
   uPortal's identity impersonation and attribute swapping features (#802)
 
 ### Changed
+
 * Removing widget from home screen now displays a toast allowing UNDO action before saving changes (#805)
 * App search results now order by matching titles first, then matching descriptions/keywords (#809)
 
 ### Fixed
+
 * Fixed bug that sometimes caused the wrong widget to be removed from user's layout (#804)
 
 ### Dependency upgrades
+
 * Updated app-framework to 9.0.1
 
 ## [8.0.0][] - 2018-03-21
 
 ### Added
+
 * Sort widget layout by keyboard -- arrow keys when the widget has focus will move it left or right (#795)
 * Added `public-myuw` to localhost mock app directory to demonstrate
   `list-of-links` widget sourcing its links from a URL rather than from direct
   configuration. (#792)
 
 ### Changed
+
 * Replaced bootstrap in widget layout with CSS-grid and flex fallback (#795)
 * Replaced jQuery UI Sortable with angular-drag-and-drop-lists (#795)
 
 ### Fixed
+
 * Removed defective (always zero) search results total badge (#797)
 * Alphabetically sort by `title` not `name` in app directory browse (#791)
 * Made `relatedPortlets` arrays empty in `entries.json` (#787)
 
 ### Dependency upgrades
+
 * chore(deps): update stylelint to version 9.1.3 #793
 
 ## [7.2.0][] - 2018-01-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,17 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+and this project adheres to
+[Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][]
 
 ### Deprecated
 
-* Support for Font Awesome icons (the `faIcon` parameter in `portlet-definition` entity files) is formally deprecated,
-with Material icons (`mdIcon`) preferred instead. Documentation is updated to reflect this preference and deprecation.
-Support for Font Awesome icons will be removed in some future release.
+* Support for Font Awesome icons (the `faIcon` parameter in `portlet-definition`
+  entity files) is formally deprecated, with Material icons (`mdIcon`) preferred
+  instead. Documentation is updated to reflect this preference and deprecation.
+  Support for Font Awesome icons will be removed in some future release.
 
 ### Changed
 
@@ -37,12 +39,15 @@ Support for Font Awesome icons will be removed in some future release.
 
 ### Changed
 
-* Removing widget from home screen now displays a toast allowing UNDO action before saving changes (#805)
-* App search results now order by matching titles first, then matching descriptions/keywords (#809)
+* Removing widget from home screen now displays a toast allowing UNDO action
+  before saving changes (#805)
+* App search results now order by matching titles first, then matching
+  descriptions/keywords (#809)
 
 ### Fixed
 
-* Fixed bug that sometimes caused the wrong widget to be removed from user's layout (#804)
+* Fixed bug that sometimes caused the wrong widget to be removed from user's
+  layout (#804)
 
 ### Dependency upgrades
 
@@ -52,7 +57,8 @@ Support for Font Awesome icons will be removed in some future release.
 
 ### Added
 
-* Sort widget layout by keyboard -- arrow keys when the widget has focus will move it left or right (#795)
+* Sort widget layout by keyboard -- arrow keys when the widget has focus will
+  move it left or right (#795)
 * Added `public-myuw` to localhost mock app directory to demonstrate
   `list-of-links` widget sourcing its links from a URL rather than from direct
   configuration. (#792)


### PR DESCRIPTION
Trivial. Just being obsessive.

`npm run lint-md` passes locally.

```
$ npm run lint-md

> @uportal/home@7.0.1 lint-md /Users/apetro/code/github_uportal/uportal-home
> remark . --frail --ignore-path .gitignore

CHANGELOG.md: no issues found
CODE_OF_CONDUCT.md: no issues found
README.md: no issues found
SUPPORT.md: no issues found
committers.md: no issues found
docs/README.md: no issues found
docs/apereo-incubation.md: no issues found
docs/app-directory.md: no issues found
docs/compact.md: no issues found
docs/contributors.md: no issues found
docs/expanded.md: no issues found
docs/impersonation.md: no issues found
docs/presentations.md: no issues found
docs/releasing.md: no issues found
docs/roadmap.md: no issues found
docs/screenshots.md: no issues found
docs/search.md: no issues found
docs/silent-login.md: no issues found
docs/with-uportal.md: no issues found
mock-portal/README.md: no issues found
src/main/webapp/README.md: no issues found
web/src/main/webapp/js/README.md: no issues found
web/src/main/webapp/staticFeeds/README.md: no issues found
```

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
