### PR TITLE
fix(search): gracefully handle more directory search failure modalities

### DIFF
--- a/web/src/main/webapp/my-app/search/controllers.js
+++ b/web/src/main/webapp/my-app/search/controllers.js
@@ -119,13 +119,21 @@ define([
                   results.errors[1] &&
                   results.errors[1].error_msg) {
                 if (results.errors[0].code == 4) {
+                  $log.warn(
+                    "Too many directory results for term " + $scope.searchTerm);
                   $scope.wiscDirectoryTooManyResults = true;
+                } else {
+                  $log.warn(
+                    "Directory search error [" + results.errors[1].error_msg +
+                    "] on term " + $scope.searchTerm);
                 }
+
                 $scope.wiscDirectoryErrorMessage= results.errors[1].error_msg;
               }
             }
             return results;
           }).catch(function() {
+            $log.warn("Directory search error on term " + $scope.searchTerm);
             $scope.wiscDirectoryLoading = false;
             $scope.wiscDirectoryError = true;
           }

--- a/web/src/main/webapp/my-app/search/partials/directory-results.html
+++ b/web/src/main/webapp/my-app/search/partials/directory-results.html
@@ -24,11 +24,24 @@
 </h4>
 
 <div layout="row" layout-align="center center">
-  <loading-gif data-object="wiscDirectoryResults" data-empty="wiscDirectoryResultsEmpty"></loading-gif>
+  <loading-gif
+    ng-show="wiscDirectoryLoading"
+    data-object="wiscDirectoryResults"
+    data-empty="wiscDirectoryResultsEmpty"></loading-gif>
 </div>
 <div ng-show="wiscDirectoryResultsEmpty && !wiscDirectoryTooManyResults" class='no-result'>
   No directory results.
 </div>
+
+<div ng-if="wiscDirectoryError" layout="row" layout-align="center center">
+  <p ng-if="wiscDirectoryErrorMessage">
+    {{wiscDirectoryErrorMessage}}
+  </p>
+  <p ng-if="!wiscDirectoryErrorMessage">
+    Error. Unable to search the directory.
+  </p>
+</div>
+
 <div class="result" ng-repeat="item in wiscDirectoryResults | limitTo:wiscDirectoryResultLimit">
   <h4>{{item.fullName}}</h4>
   <p ng-if="item.formalName">Also known as {{item.formalName}}</p>
@@ -61,8 +74,5 @@
 <div class="seeMoreResults">
   <p ng-if="wiscDirectoryResultCount>wiscDirectoryResultLimit">
     <a href="" ng-click="showAllDirectoryResults()">See all {{wiscDirectoryResultCount}} directory results</a>
-  </p>
-  <p ng-if="wiscDirectoryErrorMessage">
-    {{wiscDirectoryErrorMessage}}
   </p>
 </div>


### PR DESCRIPTION
When directory search fails for bad directory search URL config,
fail with user-facing message and console log message, and stop the loading indicator.