### PR TITLE
fix: hide loading indicator when app dir search returns zero results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to
 
 ### Fixed
 
+* Hide app directory search loading indicator when search returns zero results
+  (#826)
+
 ## [8.2.0][] - 2018-06-22
 
 ### Changed

--- a/web/src/main/webapp/my-app/search/controllers.js
+++ b/web/src/main/webapp/my-app/search/controllers.js
@@ -182,6 +182,8 @@ define([
         initwiscDirectoryResultLimit();
         $scope.myuwResults = [];
         $scope.filteredApps = [];
+        $scope.appDirectoryLoading = true;
+        $scope.appDirectoryErrorMessage = '';
         $scope.googleResults = [];
         $scope.directoryEnabled = false;
         $scope.wiscDirectoryResults = [];
@@ -200,9 +202,13 @@ define([
         marketplaceService.getPortlets().then(function(data) {
             $scope.myuwResults = data.portlets;
             filterAppsBySearchTerm(data.portlets);
+            $scope.appDirectoryLoading = false;
             return data;
         }).catch(function() {
           $log.warn('Could not getPortlets');
+          $scope.appDirectoryLoading = false;
+          $scope.appDirectoryErrorMessage =
+            'Error: Could not load app directory.';
         });
       };
       init();

--- a/web/src/main/webapp/my-app/search/partials/marketplace-results.html
+++ b/web/src/main/webapp/my-app/search/partials/marketplace-results.html
@@ -23,7 +23,12 @@
   {{ portal.theme.title }}
 </h4>
 <div layout="row" layout-align="center center">
-  <loading-gif data-object="filteredApps"></loading-gif>
+  <loading-gif
+    ng-show="appDirectoryLoading"
+    data-object="filteredApps"></loading-gif>
+</div>
+<div ng-show="appDirectoryErrorMessage" class="no-result">
+  {{ appDirectoryErrorMessage }}
 </div>
 <div ng-show="myuwResults.length != 0 && filteredApps.length == 0" class="no-result">
   No {{ portal.theme.title }} results. <a href="apps">See all apps?</a>


### PR DESCRIPTION
Before: bugged: when search on a term that yields zero results from app directory, loading indicator keeps pointlessly spinning even though nothing more will be loaded.

![screen recording 2018-06-07 at 12 30 pm](https://user-images.githubusercontent.com/952283/41116020-cc884a72-6a4e-11e8-9d27-cf7274a45600.gif)

After: loading indicator disappears when app directory content loads and filtering completes, even if that filtering yields zero relevant results.

![after-zero-results-no-loading-indicator](https://user-images.githubusercontent.com/952283/41115851-549a1ae0-6a4e-11e8-860d-3b915e52deed.png)
