### PR TITLE
feat(search): nuance app and person dir search results badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased][]
+## [Unreleased][] (8.3.0 ?)
 
 ### Changed
+
+* App directory and person directory search result tabs now reflect more nuance
+  about the state of their respective searches in the result tab badges. (#827)
 
 ### Added
 
 ### Fixed
 
+* May have fixed a bug where app directory search result badge could get out of
+  sync with the number of search results actually being displayed. (#827)
 * Hide app directory search loading indicator when search returns zero results
   (#826)
 * Gracefully handle case where directory search JSON URL is bad, as is the case

--- a/web/src/main/webapp/my-app/search/controllers.js
+++ b/web/src/main/webapp/my-app/search/controllers.js
@@ -103,6 +103,7 @@ define([
 
       var initDirectorySearch = function() {
         $scope.wiscDirectoryLoading = true;
+        $scope.wiscDirectoryResultsBadge = '?';
         directorySearchService.directorySearch($scope.searchTerm).then(
           function(results) {
             $scope.wiscDirectoryLoading = false;
@@ -110,8 +111,10 @@ define([
               if (results.records && results.count) {
                 $scope.wiscDirectoryResults = results.records;
                 $scope.wiscDirectoryResultCount = results.count;
+                $scope.wiscDirectoryResultsBadge = results.count;
               } else {
                 $scope.wiscDirectoryResultsEmpty = true;
+                $scope.wiscDirectoryResultsBadge = '0';
               }
               if (results.errors &&
                   results.errors[0] &&
@@ -122,10 +125,12 @@ define([
                   $log.warn(
                     'Too many directory results for term ' + $scope.searchTerm);
                   $scope.wiscDirectoryTooManyResults = true;
+                  $scope.wiscDirectoryResultsBadge = '25+';
                 } else {
                   $log.warn(
                     'Directory search error [' + results.errors[1].error_msg +
                     '] on term ' + $scope.searchTerm);
+                  $scope.wiscDirectoryResultsBadge = '!';
                 }
 
                 $scope.wiscDirectoryErrorMessage= results.errors[1].error_msg;
@@ -137,6 +142,7 @@ define([
             $scope.wiscDirectoryLoading = false;
             $scope.wiscDirectoryErrorMessage =
               'Error. Unable to search the directory.';
+            $scope.wiscDirectoryResultsBadge = '!';
           }
         );
       };
@@ -192,11 +198,13 @@ define([
         $scope.myuwResults = [];
         $scope.filteredApps = [];
         $scope.appDirectoryLoading = true;
+        $scope.appDirectoryResultsBadge = '?';
         $scope.appDirectoryErrorMessage = '';
         $scope.googleResults = [];
         $scope.directoryEnabled = false;
         $scope.wiscDirectoryResults = [];
         $scope.wiscDirectoryResultCount = 0;
+        $scope.wiscDirectoryResultsBadge = '?';
         $scope.wiscDirectoryTooManyResults = false;
         $scope.googleSearchEnabled = false;
         $scope.googleResultsEstimatedCount = 0;
@@ -212,10 +220,12 @@ define([
             $scope.myuwResults = data.portlets;
             filterAppsBySearchTerm(data.portlets);
             $scope.appDirectoryLoading = false;
+            $scope.appDirectoryResultsBadge = $scope.filteredApps.length;
             return data;
         }).catch(function() {
           $log.warn('Could not getPortlets');
           $scope.appDirectoryLoading = false;
+          $scope.appDirectoryResultsBadge = '!';
           $scope.appDirectoryErrorMessage =
             'Error: Could not load app directory.';
         });

--- a/web/src/main/webapp/my-app/search/partials/search-results.html
+++ b/web/src/main/webapp/my-app/search/partials/search-results.html
@@ -69,7 +69,7 @@
       <!-- MyUW RESULTS ONLY -->
       <md-tab ng-if="googleSearchEnabled || directoryEnabled">
         <md-tab-label>
-          {{ portal.theme.title }}&nbsp;&nbsp;<span class="badge">{{ filteredApps.length }}</span>
+          {{ portal.theme.title }}&nbsp;&nbsp;<span class="badge">{{ appDirectoryResultsBadge }}</span>
         </md-tab-label>
         <md-tab-body>
           <md-content>
@@ -84,7 +84,8 @@
       <!-- DIRECTORY RESULTS ONLY -->
       <md-tab ng-if="directoryEnabled">
         <md-tab-label>
-          Directory&nbsp;&nbsp;<span class="badge">{{ wiscDirectoryTooManyResults ? '25+' : wiscDirectoryResultCount }}</span>
+          Directory&nbsp;&nbsp;
+          <span class="badge">{{ wiscDirectoryResultsBadge }}</span>
         </md-tab-label>
         <md-tab-body>
           <md-content>


### PR DESCRIPTION
Differentiate zero results from loading and error states, in the badges on the app directory and person directory search results tabs. Intended to better set user expectations about whether results have returned and what they'll find on those tabs if they click *now*. Also intended to incidentally fix some kind of bug about the search results indicated on tab not staying in sync with the search results as displayed.

Refactors to move badge computation to controller rather than in partial, simplifying partial and moving this state change closer to where related state changes.

May need some user testing. Users might appreciate and delight in this nuance, especially on a slooooow connection, or they may find it hard to understand or annoying?

After:

![fancy-search-results-badges](https://user-images.githubusercontent.com/952283/41124393-716dbc76-6a67-11e8-818f-c5feebf9f317.gif)
