### PR TITLE
fix(search): show no-results div when no results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 
 * Hide app directory search loading indicator when search returns zero results
   (#826)
+* Suggest ways to recover from a search with zero results (#828)
 * Gracefully handle case where directory search JSON URL is bad, as is the case
   in naive localhost demo against stub data (#825)
 

--- a/web/src/main/webapp/my-app/search/controllers.js
+++ b/web/src/main/webapp/my-app/search/controllers.js
@@ -103,6 +103,7 @@ define([
 
       var initDirectorySearch = function() {
         $scope.wiscDirectoryLoading = true;
+        $scope.wiscDirectoryHopeForResults = true;
         directorySearchService.directorySearch($scope.searchTerm).then(
           function(results) {
             $scope.wiscDirectoryLoading = false;
@@ -110,8 +111,10 @@ define([
               if (results.records && results.count) {
                 $scope.wiscDirectoryResults = results.records;
                 $scope.wiscDirectoryResultCount = results.count;
+                // hope for results is well justified, leave it true
               } else {
                 $scope.wiscDirectoryResultsEmpty = true;
+                $scope.wiscDirectoryHopeForResults = false;
               }
               if (results.errors &&
                   results.errors[0] &&
@@ -126,6 +129,7 @@ define([
                   $log.warn(
                     'Directory search error [' + results.errors[1].error_msg +
                     '] on term ' + $scope.searchTerm);
+                  $scope.wiscDirectoryHopeForResults = false;
                 }
 
                 $scope.wiscDirectoryErrorMessage= results.errors[1].error_msg;
@@ -137,6 +141,7 @@ define([
             $scope.wiscDirectoryLoading = false;
             $scope.wiscDirectoryErrorMessage =
               'Error. Unable to search the directory.';
+            $scope.wiscDirectoryHopeForResults = false;
           }
         );
       };
@@ -181,6 +186,10 @@ define([
             .filter(function(i) {
               return appsWithMatchingTitle.indexOf(i) === -1;
         }));
+
+        if ($scope.filteredApps.length === 0) {
+          $scope.appDirectoryHopeForResults = false;
+        }
       };
 
       $scope.showAllDirectoryResults = function() {
@@ -194,13 +203,20 @@ define([
         $scope.appDirectoryLoading = true;
         $scope.appDirectoryErrorMessage = '';
         $scope.googleResults = [];
+        // there's hope when there are or might be nonzero results
+        // hopeless when we know there will be no results to show
+        $scope.appDirectoryHopeForResults = true;
+
         $scope.directoryEnabled = false;
         $scope.wiscDirectoryResults = [];
         $scope.wiscDirectoryResultCount = 0;
         $scope.wiscDirectoryTooManyResults = false;
+        $scope.wiscDirectoryHopeForResults = false;
+
         $scope.googleSearchEnabled = false;
         $scope.googleResultsEstimatedCount = 0;
         $scope.googleEmptyResults = false;
+        $scope.googleHopeForResults = false;
         $scope.searchResultLimit = 20;
         $scope.showAll = $rootScope.GuestMode || false;
         base.setupSearchTerm();
@@ -218,6 +234,7 @@ define([
           $scope.appDirectoryLoading = false;
           $scope.appDirectoryErrorMessage =
             'Error: Could not load app directory.';
+          $scope.appDirectoryHopeForResults = false;
         });
       };
       init();

--- a/web/src/main/webapp/my-app/search/controllers.js
+++ b/web/src/main/webapp/my-app/search/controllers.js
@@ -202,7 +202,6 @@ define([
         $scope.filteredApps = [];
         $scope.appDirectoryLoading = true;
         $scope.appDirectoryErrorMessage = '';
-        $scope.googleResults = [];
         // there's hope when there are or might be nonzero results
         // hopeless when we know there will be no results to show
         $scope.appDirectoryHopeForResults = true;
@@ -214,6 +213,7 @@ define([
         $scope.wiscDirectoryHopeForResults = false;
 
         $scope.googleSearchEnabled = false;
+        $scope.googleResults = [];
         $scope.googleResultsEstimatedCount = 0;
         $scope.googleEmptyResults = false;
         $scope.googleHopeForResults = false;

--- a/web/src/main/webapp/my-app/search/partials/search-results.html
+++ b/web/src/main/webapp/my-app/search/partials/search-results.html
@@ -31,13 +31,12 @@
         <md-tab-body>
           <md-content>
 
-           <!-- No search results found -->
+           <!-- No results and no hope for results;
+            Offer some failed search recovery suggestions. -->
            <div id="no-results" class="search-results-container search-results"
-              ng-show="!appDirectoryLoading && filteredApps.length == 0
-                && (!directoryEnabled ||
-                  (!wiscDirectoryTooManyResults
-                    && wiscDirectoryResultCount == 0))
-                && (!googleSearchEnabled || googleEmptyResults)">
+              ng-show="!appDirectoryHopeForResults
+                && !wiscDirectoryHopeForResults
+                && !googleHopeForResults">
               <p><strong>No matches.</strong></p>
               <p>Suggestions:</p>
               <p ng-if="kbSearchUrl">

--- a/web/src/main/webapp/my-app/search/partials/search-results.html
+++ b/web/src/main/webapp/my-app/search/partials/search-results.html
@@ -30,6 +30,41 @@
         </md-tab-label>
         <md-tab-body>
           <md-content>
+
+           <!-- No search results found -->
+           <div id="no-results" class="search-results-container search-results"
+              ng-show="!appDirectoryLoading && filteredApps.length == 0
+                && (!directoryEnabled ||
+                  (!wiscDirectoryTooManyResults
+                    && wiscDirectoryResultCount == 0))
+                && (!googleSearchEnabled || googleEmptyResults)">
+              <p><strong>No matches.</strong></p>
+              <p>Suggestions:</p>
+              <p ng-if="kbSearchUrl">
+                Search the
+                  <a ng-href="{{kbSearchUrl}}{{searchText}}"
+                    target="_blank" rel="noopener noreferrer">
+                      KnowledgeBase</a>
+              </p>
+              <p ng-if="eventsSearchUrl">
+                Look for
+                  <a ng-href="{{eventsSearchUrl}}{{searchText}}"
+                    target="_blank" rel="noopener noreferrer">
+                    events</a>
+              </p>
+              <p ng-if="helpdeskUrl">
+                Get help from the
+                  <a ng-href="{{helpdeskUrl}}"
+                  target="_blank" rel="noopener noreferrer">
+                    Help Desk</a>
+              </p>
+              <p ng-if="feedbackUrl">
+                <a ng-href="{{feedbackUrl}}"
+                  target="_blank" rel="noopener noreferrer">Give feedback</a>
+                on {{portal.theme.title}} search
+              </p>
+            </div>
+
             <!-- MyUW results -->
             <div class="search-results-container">
               <marketplace-results></marketplace-results>
@@ -43,24 +78,6 @@
             <!--Campus domain results-->
             <div ng-show="googleSearchEnabled" class="search-results-container">
               <campus-domain-results></campus-domain-results>
-            </div>
-
-            <!-- No search results found -->
-            <div id="no-results" class="search-results-container search-results" ng-show="totalCount === 0">
-              <p><strong>No matches.</strong></p>
-              <p>Suggestions:</p>
-              <p ng-if="kbSearchUrl">
-                Search the <a ng-href="{{kbSearchUrl}}{{searchText}}" target="_blank" rel="noopener noreferrer">KnowledgeBase</a>
-              </p>
-              <p ng-if="eventsSearchUrl">
-                Look for <a ng-href="{{eventsSearchUrl}}{{searchText}}" target="_blank" rel="noopener noreferrer">events</a>
-              </p>
-              <p ng-if="helpdeskUrl">
-                Get help from the <a ng-href="{{helpdeskUrl}}" target="_blank" rel="noopener noreferrer">Help Desk</a>
-              </p>
-              <p ng-if="feedbackUrl">
-                <a ng-href="{{feedbackUrl}}" target="_blank" rel="noopener noreferrer">Give feedback</a> on {{portal.theme.title}} search
-              </p>
             </div>
           </md-content>
         </md-tab-body>


### PR DESCRIPTION
Had been bugged such that no-search-results recovery suggestions would never show.
Change to show when there's no hope of results.

After: no results:

![image 2018-06-08 at 7 37 09 am](https://user-images.githubusercontent.com/952283/41158726-9f9a6774-6aef-11e8-9db9-9ad0956d5a3c.png)


After: some results

![image 2018-06-08 at 7 39 07 am](https://user-images.githubusercontent.com/952283/41158743-ab9e0d28-6aef-11e8-8ffd-493a8d024222.png)
