### PR TITLE
fix(search): successfully launch into today.wisc.edu from Madison theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
 
 ### Fixed
 
+* Successfully launch searches into today.wisc.edu from Madison's theme (#829)
+
 ### Deprecated
 
 **Web search integration is deprecated.** This integration is not actually used
@@ -33,7 +35,6 @@ It's not that this feature is unwelcome, it's just that it's not currently real.
 * Hide app directory search loading indicator when search returns zero results
   (#826)
 * Suggest ways to recover from a search with zero results (#828)
-* Successfully launch searches into today.wisc.edu from Madison's theme (#829)
 * Gracefully handle case where directory search JSON URL is bad, as is the case
   in naive localhost demo against stub data (#825)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 
 * Hide app directory search loading indicator when search returns zero results
   (#826)
+* Successfully launch searches into today.wisc.edu from Madison's theme (#829)
 * Gracefully handle case where directory search JSON URL is bad, as is the case
   in naive localhost demo against stub data (#825)
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -56,7 +56,7 @@ Search is configured in `web-config.js`:
     "webSearchURL" : "http://www.wisc.edu/search/?q=",
     "domainResultsLabel" : "Wisc.edu",
     "kbSearchURL" : "https://kb.wisc.edu/search.php?q=",
-    "eventsSearchURL" : "https://today.wisc.edu/events/search?term=",
+    "eventsSearchURL" : "https://today.wisc.edu/events/search?search[term]=",
     "helpdeskURL" : "https://kb.wisc.edu/helpdesk/"
   },
   {

--- a/web/src/main/webapp/js/web-config.js
+++ b/web/src/main/webapp/js/web-config.js
@@ -26,7 +26,7 @@ define(['angular'], function(angular) {
         'webSearchURL': 'http://www.wisc.edu/search/?q=',
         'domainResultsLabel': 'Wisc.edu',
         'kbSearchURL': 'https://kb.wisc.edu/search.php?q=',
-        'eventsSearchURL': 'https://today.wisc.edu/events/search?term=',
+        'eventsSearchURL': 'https://today.wisc.edu/events/search?search[term]=',
         'helpdeskURL': 'https://kb.wisc.edu/helpdesk/',
       },
       {


### PR DESCRIPTION
query parameter changed from `term` to `search[term]`