### PR TITLE
feat(search): deprecate Web search integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,13 @@ and this project adheres to
 
 ### Deprecated
 
-**Web search integration is deprecated.** This integration is not actually in use
+**Web search integration is deprecated.** This integration is not actually used
 by `uPortal-home` adopters actively involved in maintaining this open source
-software product, so there's a lot of risk for this feature to go un-loved and
-un-maintained. Removing it will clarify expectations that one shouldn't really
-expect it to work or to be maintained -- it'll still be in the source history so
-when the feature comes up again (fair to expect it will), it'll still be
-feasible to get whatever goodness can be had from working from the legacy
-implementation of this abandoned feature.
+software product, so there's risk for this feature to go un-loved and
+un-maintained. Removing it clarifies expectations. The web search integration
+will still be in the source history so when the feature comes up again (fair to
+expect it will), it will still be feasible to get whatever goodness can be had
+from working from the legacy implementation of this abandoned feature.
 
 ## [8.2.0][] - 2018-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ and this project adheres to
 * Gracefully handle case where directory search JSON URL is bad, as is the case
   in naive localhost demo against stub data (#825)
 
+### Deprecated
+
+**Web search integration is deprecated.** This integration is not actually in use
+by `uPortal-home` adopters actively involved in maintaining this open source
+software product, so there's a lot of risk for this feature to go un-loved and
+un-maintained. Removing it will clarify expectations that one shouldn't really
+expect it to work or to be maintained -- it'll still be in the source history so
+when the feature comes up again (fair to expect it will), it'll still be
+feasible to get whatever goodness can be had from working from the legacy
+implementation of this abandoned feature.
+
 ## [8.2.0][] - 2018-06-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ un-maintained. Removing it clarifies expectations. The web search integration
 will still be in the source history so when the feature comes up again (fair to
 expect it will), it will still be feasible to get whatever goodness can be had
 from working from the legacy implementation of this abandoned feature.
+**Engagement to implement and maintain this feature going forward is welcome.**
+It's not that this feature is unwelcome, it's just that it's not currently real.
 
 ## [8.2.0][] - 2018-06-22
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -8,7 +8,9 @@ uPortal-home uses search to scale beyond the limitations of stuffing content int
 
 You can search the directory of apps.
 
-If configured, you can also search a directory of people, and the Web.
+If configured, you can also search a directory of people.
+
+Deprecated: Web search integration.
 
 ### Search the app directory
 
@@ -34,7 +36,13 @@ This is optional. If you don't configure it, the directory results section and t
 
 ### Search the Web
 
-TODO: Document expectations of this integration.
+**Deprecated.** No `uPortal-home` adopter actively involved in the maintenance
+of this open source software product relies upon this feature, so you should
+already be skeptical that it works and is maintained. Will be removed in a
+future release to more clearly set the expectation that you cannot rely upon
+this feature. This feature is nonetheless probably a great idea and if you want
+it don't hesitate to get involved in developing and maintaining this
+integration. :)
 
 This is optional. If you don't configure it, the Web results section and tab simply do not display.
 
@@ -87,7 +95,7 @@ Directory searching (optional):
 
 Web searching (optional; declare all or none):
 
-+ `googleSearchURL` : JSON web service for Web search.
++ `googleSearchURL` : JSON web service for Web search. **DEPRECATED.**
 + `webSearchURL` : human-facing URL for launching the search query into a full Web search experience. Search query will be appended.
 + `domainResultsLabel` : Your Web search doesn't search the whole Web. That's what the browser address bar is for, after all. So what does it search? This label characterizes that for the user.
 


### PR DESCRIPTION
I think it's time to admit we're not going to fix and maintain this feature soon.

Removing it will reduce friction in other development and maintenance of the search experience.

And there's no rule we can't reach into source history and pick up and run with this feature whenever that becomes the right thing to do.