### PR TITLE
fix: persist layout changes in compact mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 * Successfully launch searches into today.wisc.edu from Madison's theme (#829)
 * May have fixed a bug where app directory search result badge could get out of
   sync with the number of search results actually being displayed. (#827)
+* Fix compact mode layout changes not persisting when using click+drag (#838)
 
 ### Deprecated
 

--- a/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
+++ b/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
@@ -29,6 +29,7 @@
     </div>
     <!-- List View -->
     <ul dnd-list="layout"
+        dnd-drop="moveWithDrag(item, index)"
         dnd-horizontal-list="true"
         class="layout-list compact">
       <li class="dndPlaceholder no-padding widget-container"></li>


### PR DESCRIPTION
[MUMUP-3360](https://jira.doit.wisc.edu/jira/browse/MUMUP-3360): "As a MyUW compact widget mode user, I would like my re-ordering of my layout to persist, so that I can customize my layout and have those changes saved"

**In this PR:**
- Added a missing function call :(

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
