### PR TITLE
fix: adjust widget remove button to fit contextual menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 * App directory and person directory search result tabs now reflect more nuance
   about the state of their respective searches in the result tab badges. (#827)
+* Widget removal button is now a menu item to conform to [upstream changes][uportal-app-framework #786] (#840)
 
 ### Added
 
@@ -460,3 +461,4 @@ See also:
 [6.2.0]: https://github.com/uPortal-Project/uportal-home/compare/angularjs-portal-parent-6.1.0...angularjs-portal-parent-6.2.0
 [6.1.0]: https://github.com/uPortal-Project/uportal-home/compare/angularjs-portal-parent-6.0.0...angularjs-portal-parent-6.1.0
 [6.0.0]: https://github.com/uPortal-Project/uportal-home/compare/angularjs-portal-parent-5.5.0...angularjs-portal-parent-6.0.0
+[uportal-app-framework #786]: https://github.com/uPortal-Project/uportal-app-framework/pull/786

--- a/web/src/main/webapp/css/home.less
+++ b/web/src/main/webapp/css/home.less
@@ -34,12 +34,6 @@ default-card portlet-icon img {
   margin: 4px 10px;
 }
 
-.widget-remove {
-  top: 0;
-  position: absolute;
-  right: 0;
-}
-
 .portlet-title {
   margin: 0;
   border-top-left-radius: 3px;

--- a/web/src/main/webapp/css/widget.less
+++ b/web/src/main/webapp/css/widget.less
@@ -61,7 +61,3 @@
   width: 315px;
   margin: auto;
 }
-
-&.widget-remove {
-  right: 0;
-}

--- a/web/src/main/webapp/my-app/layout/partials/remove-button.html
+++ b/web/src/main/webapp/my-app/layout/partials/remove-button.html
@@ -18,9 +18,11 @@
     under the License.
 
 -->
-<md-button ng-controller="RemoveWidgetController as removeCtrl" class="widget-action widget-remove md-icon-button"
-           aria-label="remove {{ widget.fname }} widget from your home screen"
-           ng-click="removeCtrl.removeWidget(widget)"
-           ng-hide="GuestMode">
-  <md-icon>close</md-icon>
-</md-button>
+<md-menu-item>
+  <md-button ng-controller="RemoveWidgetController as removeCtrl"  class="widget-remove"
+             aria-label="remove {{ widget.fname }} widget from your home screen"
+             ng-click="removeCtrl.removeWidget(widget)"
+             ng-hide="GuestMode">
+    <md-icon>delete_forever</md-icon><span>Remove from home</span>
+  </md-button>
+</md-menu-item>


### PR DESCRIPTION
[https://jira.doit.wisc.edu/jira/browse/MUMUP-3297](MUMUP-3297): "As a person navigating MyUW via keyboard, I would like the less-often-used controls associated with widgets on my home tucked away into a contextual menu, so that the primary navigation is simpler."

**Companion PR:** [uportal-app-framework #786](https://github.com/uPortal-Project/uportal-app-framework/pull/786)

**In this PR:**
- Make removal button a menu item 
- Change icon to delete icon
- Add button text
- Delete unused CSS

### Screenshot
![screen shot 2018-07-10 at 11 22 52 am](https://user-images.githubusercontent.com/5818702/42523758-509359de-8434-11e8-8545-3c076d0aeaec.png)


----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
