### PR TITLE
docs(changelog): remove premature recognition of not-yet-fixed bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@ and this project adheres to
 ### Fixed
 
 * Successfully launch searches into today.wisc.edu from Madison's theme (#829)
-* May have fixed a bug where app directory search result badge could get out of
-  sync with the number of search results actually being displayed. (#827)
 * Fix compact mode layout changes not persisting when using click+drag (#838)
 
 ### Deprecated


### PR DESCRIPTION
To be fair, at the time I thought the change may have fixed the bug, just like I said.

I now know definitively it does not fix the bug, so it's no longer true that it "may".

Working on actually fixing the bug, which will make for a much more interesting pull request, but in the meantime trying to keep the CHANGELOG honest enough to support a hypothetical release before I have this fix in.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
