### PR TITLE
fix: rm app directory search results count badge, temporarily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to
 
 ### Fixed
 
+* Removes app directory search results count badge. Intended as temporary
+  mitigation for bug wherein the badge did not reliably show a correct count.
+  (#843)
 * Successfully launch searches into today.wisc.edu from Madison's theme (#829)
 * May have fixed a bug where app directory search result badge could get out of
   sync with the number of search results actually being displayed. (#827)

--- a/web/src/main/webapp/my-app/search/partials/search-results.html
+++ b/web/src/main/webapp/my-app/search/partials/search-results.html
@@ -85,7 +85,7 @@
       <!-- MyUW RESULTS ONLY -->
       <md-tab ng-if="googleSearchEnabled || directoryEnabled">
         <md-tab-label>
-          {{ portal.theme.title }}&nbsp;&nbsp;<span class="badge">{{ appDirectoryResultsBadge }}</span>
+          {{ portal.theme.title }}
         </md-tab-label>
         <md-tab-body>
           <md-content>


### PR DESCRIPTION
Mitigates bug in which the badge indicates more results than are visible to user, by removing the unreliable badge.

![no-app-directory-results-badge](https://user-images.githubusercontent.com/952283/42593138-4029d2a2-8511-11e8-874b-8cb472ae5c76.png)

Intended as temporary workaround. Suppresses a misleading badge until deeper fix to reliably show the correct number in the badge. 

Hypothesis: underlying bug is it's including in the badge count items on which user has `BROWSE` but not `SUBSCRIBE` whereas the user-visible results listing is only showing items on which user has both kinds of permission.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
