### PR TITLE
fix: do not remove compact widgets when reordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
 
 ### Fixed
 
+* Compact widgets no longer disappear when reordering via click-and-drag (#848)
+
 ### Deprecated
 
 ## [8.3.1][] - 2018-07-26

--- a/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
+++ b/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
@@ -44,7 +44,6 @@
           ng-keydown="moveWithKeyboard(widget, $event);selectNode(widget.nodeId);"
           dnd-draggable="widget"
           dnd-effect-allowed="move"
-          dnd-moved="layout.splice($index, 1)"
           dnd-dragend="logEvent('dragEnd', widget.fname, $index)">
         <compact-widget fname="{{ widget.fname }}">
           <remove-button></remove-button>


### PR DESCRIPTION
[MUMUP-3360](https://jira.doit.wisc.edu/jira/browse/MUMUP-3360): "As a MyUW compact widget mode user, I would like my re-ordering of my layout to persist, so that I can customize my layout and have those changes saved."

### Demo 
![compact](https://user-images.githubusercontent.com/5818702/43415789-1ebed0fa-93fc-11e8-920d-9cefe780d26d.gif)


----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
