### PR TITLE
fix: remove padding around fname in widget view

### DIFF
--- a/web/src/main/webapp/my-app/layout/widget/routes.js
+++ b/web/src/main/webapp/my-app/layout/widget/routes.js
@@ -23,7 +23,7 @@ define(['require'], function(require) {
     },
     widgetFullScreen: {
       template: '<div class="widget-middle">' +
-          '<widget fname=" {{ $routeParams.fname }} "></widget></div>',
+          '<widget fname="{{ $routeParams.fname }}"></widget></div>',
       controller: function($routeParams, $scope) {
         $scope.$routeParams = $routeParams;
       },


### PR DESCRIPTION
The update from angular 1.5.8 to 1.7.2 meant that directive attribute values no longer were being trimmed before put into scope. This caused a bug that looked like an authorization problem (but was actually a 500) when clicking into a compact widget.

(Pictures to come...)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
