### PR TITLE
fix: initialize cssVars after bootstrapping app

### DIFF
--- a/web/src/main/webapp/main.js
+++ b/web/src/main/webapp/main.js
@@ -36,6 +36,8 @@ require(['./config', './js/login-config'], function(config, loginConfig) {
     */
     function bootstrapApplication() {
       angular.bootstrap(document, ['my-app']);
+      // eslint-disable-next-line no-undef
+      cssVars({shadowDOM: true, watch: true});
     }
 
     /**


### PR DESCRIPTION
supplemental to https://github.com/uPortal-Project/uportal-app-framework/pull/857
Need to do this here, because this file overwrites frame's main.js

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
