### PR TITLE
fix: usable language in widget mode toggle label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to
 
 * Changed label on UI control for switching home page between expanded and
   compact widget modes, to make this feature more recognizable to and
-  understandable by users. New label is "Change widget display mode"; was
-  "Toggle expanded widgets". Also updates associated `aria-label`. #866
+  understandable by users. New label is "Change tile size"; was
+  "Toggle expanded widgets". Also updates the associated `aria-label`. #866
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to
 
 ### Fixed
 
+* Changed label on UI control for switching home page between expanded and
+  compact widget modes, to make this feature more recognizable to and
+  understandable by users. New label is "Change widget display mode"; was
+  "Toggle expanded widgets". Also updates associated `aria-label`. #866
+
 ### Deprecated
 
 ## [8.3.6][] - 2018-11-19

--- a/web/src/main/webapp/my-app/menu/partials/app-menu-template.html
+++ b/web/src/main/webapp/my-app/menu/partials/app-menu-template.html
@@ -52,11 +52,11 @@
   <md-subheader ng-if="renderMe">{{ appTitle }} Home options</md-subheader>
   <md-menu-item ng-if="renderMe">
     <md-button
-      aria-label="Toggle between expanded and compact widget display modes"
+      aria-label="Toggle between small simple tiles and larger richer tiles"
       ng-controller="ToggleController"
       ng-click="toggleMode(expandedMode)">
       <md-icon>widgets</md-icon>
-      <span>Change widget display mode</span>
+      <span>Change tile size</span>
     </md-button>
   </md-menu-item>
 </div>

--- a/web/src/main/webapp/my-app/menu/partials/app-menu-template.html
+++ b/web/src/main/webapp/my-app/menu/partials/app-menu-template.html
@@ -51,11 +51,12 @@
   </md-menu-item>
   <md-subheader ng-if="renderMe">{{ appTitle }} Home options</md-subheader>
   <md-menu-item ng-if="renderMe">
-    <md-button aria-label="Toggle expanded or compact widgets"
-               ng-controller="ToggleController"
-               ng-click="toggleMode(expandedMode)">
+    <md-button
+      aria-label="Toggle between expanded and compact widget display modes"
+      ng-controller="ToggleController"
+      ng-click="toggleMode(expandedMode)">
       <md-icon>widgets</md-icon>
-      <span>Toggle expanded widgets</span>
+      <span>Change widget display mode</span>
     </md-button>
   </md-menu-item>
 </div>


### PR DESCRIPTION
From "Toggle expanded widgets" to "Change tile size".  As I understand it, user testing flagged the status quo label as problematic.

Credit to @mrdahman for user testing that flagged this, heuristic analysis, input. Quite possibly additional credit will be due through additional iteration, testing, usability analysis.

This may take more iterations, and when it comes right down to it this UI control may need to be more stateful (dynamic label, look like a toggle or slider, ...) Would a tool tip help? Link to documentation?

Status quo:

![Screenshot of status quo sidebar menu item with current label Toggle expanded widgets](https://user-images.githubusercontent.com/952283/49443602-898ff900-f792-11e8-9a07-08407c1a0f1e.png)


After this change:

![Screenshot of changed sidebar menu item with new label Change widget display mode](https://user-images.githubusercontent.com/952283/49443577-79781980-f792-11e8-86a3-df15aaa94da8.png)

----

Tracked internally to MyUW as [MUMUP-3435](https://jira.doit.wisc.edu/jira/browse/MUMUP-3435).

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
