### PR TITLE
fix: rm "Rate {app}" button from exclusive and static partials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to
 
 ### Fixed
 
-* Removed rate app button from `exclusive` and `static` templates
+* Removed rate app button from `exclusive` and `static` templates #868
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
 
 ### Fixed
 
+* Removed rate app button from `exclusive` and `static` templates
+
 ### Deprecated
 
 ## [8.3.6][] - 2018-11-19

--- a/web/src/main/webapp/my-app/layout/static/partials/static-content-exclusive.html
+++ b/web/src/main/webapp/my-app/layout/static/partials/static-content-exclusive.html
@@ -25,9 +25,6 @@
   <frame-page ng-if="loaded" app-title="{{ portlet.title }}" app-icon="{{ portlet.faIcon }}" page-title="{{ portlet.title }}" app-fname="portlet.fname" app-show-add-to-home="true">
     <md-card>
       <div ng-bind-html="::portlet.exclusiveContent" class="up-portlet-content-wrapper" id="content-{{ ::portlet.nodeId }}"></div>
-      <div layout="row" layout-align="end center">
-        <rating-button ng-if="loaded" ng-hide="guestMode" portlet="portlet" button-text="Rate {{ portlet.title }}"></rating-button>
-      </div>
     </md-card>
   </frame-page>
 </div>

--- a/web/src/main/webapp/my-app/layout/static/partials/static-content-max.html
+++ b/web/src/main/webapp/my-app/layout/static/partials/static-content-max.html
@@ -25,9 +25,6 @@
   <frame-page ng-if="loaded" app-title="{{ portlet.title }}" app-icon="{{ portlet.faIcon }}" page-title="{{ portlet.title }}" app-fname="portlet.fname" app-show-add-to-home="true">
     <md-card>
       <div ng-bind-html="::portlet.staticContent" class="up-portlet-content-wrapper" id="content-{{ ::portlet.nodeId }}"></div>
-      <div layout="row" layout-align="end center">
-        <rating-button ng-if="loaded" ng-hide="guestMode" portlet="portlet" button-text="Rate {{ portlet.title }}"></rating-button>
-      </div>
     </md-card>
   </frame-page>
 </div>


### PR DESCRIPTION
App rating UI control for `/web/static/{fname}` and `/web/exclusive/{fname}` never caught on, drop it.

----

Within MyUW, tracked as [MUMUP-3233](https://jira.doit.wisc.edu/jira/browse/MUMUP-3233)

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
