### PR TITLE
fix: rm watch configuration from cssVars

### DIFF
--- a/web/src/main/webapp/main.js
+++ b/web/src/main/webapp/main.js
@@ -36,6 +36,7 @@ require(['./config', './js/login-config'], function(config, loginConfig) {
     */
     function bootstrapApplication() {
       angular.bootstrap(document, ['my-app']);
+      // eslint-disable-next-line angular/timeout-service
       setTimeout(function() {
         // eslint-disable-next-line no-undef
         cssVars({shadowDOM: true});

--- a/web/src/main/webapp/main.js
+++ b/web/src/main/webapp/main.js
@@ -36,8 +36,10 @@ require(['./config', './js/login-config'], function(config, loginConfig) {
     */
     function bootstrapApplication() {
       angular.bootstrap(document, ['my-app']);
-      // eslint-disable-next-line no-undef
-      cssVars({shadowDOM: true, watch: true});
+      setTimeout(function() {
+        // eslint-disable-next-line no-undef
+        cssVars({shadowDOM: true});
+      }, 1000);
     }
 
     /**


### PR DESCRIPTION
removing watch configuration from cssVars, because it makes the loading excruciatingly slow in IE11. Delaying the init by one second, because trying to run it directly after the bootstrapping is too early for IE on the first render.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
