### PR TITLE
docs(changelog): fix 9.0.0 characterization of announcement treatment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,20 @@ and this project adheres to
 
 No changes so far
 
+### Documentation in unreleased
+
+* Fixed 9.0.0 changelog entry to correctly characterize nature of breaking
+  change to messageType anouncement.
+
 ## [9.0.0][] - 2019-02-26
 
-Breaking change: messages of type `announcement` no longer have any effect.
+Breaking change: Messages of type `announcement` are no longer treated
+differently. All messages, regardless of `messageType`, are treated as if they
+were of `messageType` `notification`.
+
+(These release notes previously erroneously characterized this change as making
+messages of type `announcement` have no effect.)
+
 `/features` no longer routed.
 
 Via [uPortal-app-framework 12.0.0][]:


### PR DESCRIPTION
My bad: I'd misunderstood the way in which uPortal-app-framework removes support for `messageType` `announcement`. Apparently they don't become no-ops. It's more than `messageType` no longer has an effect and all messages are treated as if they were `notification` type.

Band-aids the changelog to reflect this understanding gained from putting uPortal-home 9.0.0 into production and getting unexpected bell notification behavior.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
