### PR TITLE
fix: id static content div with fname rather than nodeId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to
 
 ## [Unreleased][]
 
-No changes so far
+* Generate static content div identifier by fname rather than by
+  not-reliably-unique nodeId #876
 
 ## [9.0.0][] - 2019-02-26
 

--- a/web/src/main/webapp/my-app/layout/static/partials/static-content-exclusive.html
+++ b/web/src/main/webapp/my-app/layout/static/partials/static-content-exclusive.html
@@ -24,7 +24,7 @@
   </div>
   <frame-page ng-if="loaded" app-title="{{ portlet.title }}" app-icon="{{ portlet.faIcon }}" page-title="{{ portlet.title }}" app-fname="portlet.fname" app-show-add-to-home="true">
     <md-card>
-      <div ng-bind-html="::portlet.exclusiveContent" class="up-portlet-content-wrapper" id="content-{{ ::portlet.nodeId }}"></div>
+      <div ng-bind-html="::portlet.exclusiveContent" class="up-portlet-content-wrapper" id="content-{{ ::portlet.fname }}"></div>
     </md-card>
   </frame-page>
 </div>

--- a/web/src/main/webapp/my-app/layout/static/partials/static-content-max.html
+++ b/web/src/main/webapp/my-app/layout/static/partials/static-content-max.html
@@ -24,7 +24,7 @@
   </div>
   <frame-page ng-if="loaded" app-title="{{ portlet.title }}" app-icon="{{ portlet.faIcon }}" page-title="{{ portlet.title }}" app-fname="portlet.fname" app-show-add-to-home="true">
     <md-card>
-      <div ng-bind-html="::portlet.staticContent" class="up-portlet-content-wrapper" id="content-{{ ::portlet.nodeId }}"></div>
+      <div ng-bind-html="::portlet.staticContent" class="up-portlet-content-wrapper" id="content-{{ ::portlet.fname}}"></div>
     </md-card>
   </frame-page>
 </div>


### PR DESCRIPTION
In practice nodeId is always (often?) -1, so instead use `fname` to generate HTML element IDs.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
