### PR TITLE
fix: add flexbox fallback for compact widget grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to
 * Generate static content div identifier by fname rather than by
   not-reliably-unique nodeId #876
 
+### Fixed
+
+* Fixed widget grid not displaying properly in Firefox #881
+
 ## [9.0.0][] - 2019-02-26
 
 Breaking change: messages of type `announcement` no longer have any effect.

--- a/web/src/main/webapp/css/home.less
+++ b/web/src/main/webapp/css/home.less
@@ -235,6 +235,7 @@ div.table-cell {
   }
 
   &.compact {
+    justify-content: center;
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     grid-auto-rows: minmax(150px, 1fr);
     grid-gap: 10px;


### PR DESCRIPTION
**In this PR**:
- Firefox doesn't like the CSS-grid for displaying compact widgets -- added a flexbox fallback to center-align the grid

### Screenshot
<img width="997" alt="Screen Shot 2019-04-22 at 11 42 53 AM" src="https://user-images.githubusercontent.com/5818702/56512153-2cec6b00-64f4-11e9-8d0d-8e704cf8774b.png">


----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
