### PR TITLE
docs: add reminder to examine for security impact to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,12 @@
 
 ----
 
+Review for security considerations
+
+<!-- Place an x in the checkbox for YES. -->
+
+- [ ] The change has been examined for security impact.
+
 Contributor License Agreement adherence:
 
 <!-- Place an x in the checkbox for YES. -->


### PR DESCRIPTION
Review of MyUW against the (UW Office of Cybersecurity) [Risk Management Framework](https://it.wisc.edu/about/division-of-information-technology/strategic-operations-departments-people/cybersecurity/risk-management-framework) flagged a need to add process to ensure changes are reviewed for security impact.

This PR would add a checkbox to the Pull Request template to remind to examine changes for security impact.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

----

Tracked internally to MyUW as [MUMMNG-4659](https://jira.doit.wisc.edu/jira/browse/MUMMNG-4659).