### PR TITLE
docs: fix 9.1.0 sub-headings to reflect released 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ and this project adheres to
 
 ## [9.1.0][] - 2019-05-13
 
-### Fixes in unreleased
+### Fixes in 9.1.0
 
 * Generates static content div identifier by fname rather than by
   not-reliably-unique nodeId #876
 * Fixes widget grid not displaying properly in Firefox #881
 
-### Dependency upgrades in unreleased
+### Dependency upgrades in 9.1.0
 
 Upgrades to uPortal-app-framework 12.1.0 from 12.0.0. Highlights:
 


### PR DESCRIPTION
In 9.1.0 release had overlooked some sub-headings that needed change to reflect the release state change.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
