### PR TITLE
docs: remove wiscdirectory local proxy example

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -59,7 +59,7 @@ Search is configured in `web-config.js`:
 .value('SEARCH_CONFIG', [
   {
     "group" : "UW-Madison",
-    "directorySearchURL" : "/web/api/proxy/wiscdirectory",
+    "directorySearchURL" : "/aries/proxy/wiscdirectory",
     "googleSearchURL" : "/web/api/proxy/wiscedusearch?v=1.0&rsz=10&start=0&cx=02:22m",
     "webSearchURL" : "http://www.wisc.edu/search/?q=",
     "domainResultsLabel" : "Wisc.edu",

--- a/web/src/main/resources/endpoint.properties.example
+++ b/web/src/main/resources/endpoint.properties.example
@@ -46,8 +46,6 @@ uwmadisonreddit.username=
 uwmadisonreddit.password=
 uwmadisonreddit.attributes=
 
-wiscdirectory.uri=http://www.wisc.edu/directories/json
-
 wiscedusearch.uri=https://www.googleapis.com/customsearch/v1element
 
 uwrfsearch.uri=https://www.googleapis.com/customsearch/v1element


### PR DESCRIPTION
MyUW no longer runs this proxy out of a uPortal-home embed, instead deploying a separate proxy instance, so as is these docs are confusing; with this change this is slightly less confusing.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
