### PR TITLE
always offer search recovery options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to
 
 * Removes embedded rest-proxy. Local implementations of uPortal-home needing a
   proxy should deploy a proxy alongside rather than within uPortal-home.
+* Always shows suggestions for recovering from search not finding what the user
+  needs, instead of only showing these options when there were no search
+  results. (There might be results, but those results may not have met the user
+  need).
 
 ## [9.2.0][] - 2019-06-07
 

--- a/web/src/main/webapp/css/search-results.less
+++ b/web/src/main/webapp/css/search-results.less
@@ -27,7 +27,7 @@
     }
   }
 
-  .no-result {
+  .other-search-options {
     padding: 10px 16px;
   }
 

--- a/web/src/main/webapp/my-app/search/partials/search-results.html
+++ b/web/src/main/webapp/my-app/search/partials/search-results.html
@@ -31,39 +31,6 @@
         <md-tab-body>
           <md-content>
 
-           <!-- No results and no hope for results;
-            Offer some failed search recovery suggestions. -->
-           <div id="no-results" class="search-results-container search-results"
-              ng-show="!appDirectoryHopeForResults
-                && !wiscDirectoryHopeForResults
-                && !googleHopeForResults">
-              <p><strong>No matches.</strong></p>
-              <p>Suggestions:</p>
-              <p ng-if="kbSearchUrl">
-                Search the
-                  <a ng-href="{{kbSearchUrl}}{{searchText}}"
-                    target="_blank" rel="noopener noreferrer">
-                      KnowledgeBase</a>
-              </p>
-              <p ng-if="eventsSearchUrl">
-                Look for
-                  <a ng-href="{{eventsSearchUrl}}{{searchText}}"
-                    target="_blank" rel="noopener noreferrer">
-                    events</a>
-              </p>
-              <p ng-if="helpdeskUrl">
-                Get help from the
-                  <a ng-href="{{helpdeskUrl}}"
-                  target="_blank" rel="noopener noreferrer">
-                    Help Desk</a>
-              </p>
-              <p ng-if="feedbackUrl">
-                <a ng-href="{{feedbackUrl}}"
-                  target="_blank" rel="noopener noreferrer">Give feedback</a>
-                on {{portal.theme.title}} search
-              </p>
-            </div>
-
             <!-- MyUW results -->
             <div class="search-results-container">
               <marketplace-results></marketplace-results>
@@ -78,6 +45,52 @@
             <div ng-show="googleSearchEnabled" class="search-results-container">
               <campus-domain-results></campus-domain-results>
             </div>
+
+           <!-- Offer some failed search recovery suggestions. -->
+            <div id="other-search-options"
+              class="search-results-container search-results">
+
+              <h4 class="md-subhead">
+                <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
+                Not finding what you need?
+              </h4>
+
+              <div class="result" ng-if="kbSearchUrl">
+                <h4>
+                  <a ng-href="{{kbSearchUrl}}{{searchText}}"
+                    target="_blank" rel="noopener noreferrer">
+                    Search the KnowledgeBase</a>
+                </h4>
+              </div>
+
+              <div class="result" ng-if="eventsSearchUrl">
+                <h4>
+                  <a ng-href="{{eventsSearchUrl}}{{searchText}}"
+                    target="_blank" rel="noopener noreferrer">
+                    Look for events</a>
+                </h4>
+              </div>
+
+              <div class="result" ng-if="helpdeskUrl">
+                <h4>
+                  <a ng-href="{{helpdeskUrl}}"
+                    target="_blank" rel="noopener noreferrer">
+                    Get help from the Help Desk</a>
+                </h4>
+              </div>
+
+              <div class="result" ng-if="feedbackUrl">
+                <h4>
+                  <a ng-href="{{feedbackUrl}}"
+                    target="_blank" rel="noopener noreferrer">
+                    Give feedback on {{portal.theme.title}} search</a>
+                </h4>
+              </div>
+
+            </div>
+
+          </div>
+
           </md-content>
         </md-tab-body>
       </md-tab>


### PR DESCRIPTION
Rather than only showing the failed search recovery options when there were no search results at all, instead always show these options so that if there were results but those results were not helpful, shows recovery options.

This is a change in presentation in otherwise unchanged content.

Before:

<img width="953" alt="when-results-no-suggestions" src="https://user-images.githubusercontent.com/952283/63283129-17a30580-c276-11e9-8ac6-0dab2522d6a3.png">

After:

<img width="859" alt="recovery-options-at-bottom" src="https://user-images.githubusercontent.com/952283/63283153-27bae500-c276-11e9-93ed-10781c4a1e1f.png">

The options:

<img width="317" alt="search-recovery-options" src="https://user-images.githubusercontent.com/952283/63283175-35706a80-c276-11e9-93e1-0ad45507fa61.png">

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
