### PR TITLE
Add "Other" tab in search suggesting search widgets

### DIFF
--- a/web/src/main/webapp/my-app/search/partials/search-results.html
+++ b/web/src/main/webapp/my-app/search/partials/search-results.html
@@ -143,28 +143,28 @@
           <md-content>
             <div layout="row" layout-align="center start" style="flex-wrap:wrap;padding:18px;">
               <div flex-xs="100" class="widget-container">
-                <widget fname="wisc-kb"></widget>
+                <widget fname="wisc-kb" fail-silently="true"></widget>
               </div>
               <div flex-xs="100" class="widget-container">
-                <widget fname="uwec-kb"></widget>
+                <widget fname="uwec-kb" fail-silently="true"></widget>
               </div>
               <div flex-xs="100" class="widget-container">
-                <widget fname="madison-public-course-search"></widget>
+                <widget fname="madison-public-course-search" fail-silently="true"></widget>
               </div>
               <div flex-xs="100" class="widget-container">
-                <widget fname="ResearcherPortlet"></widget>
+                <widget fname="ResearcherPortlet" fail-silently="true"></widget>
               </div>
               <div flex-xs="100" class="widget-container">
-                <widget fname="rprg"></widget>
+                <widget fname="rprg" fail-silently="true"></widget>
               </div>
               <div flex-xs="100" class="widget-container">
-                <widget fname="ResearcherPortlet"></widget>
+                <widget fname="ResearcherPortlet" fail-silently="true"></widget>
               </div>
               <div flex-xs="100" class="widget-container">
-                <widget fname="directory-of-resources-for-researchers"></widget>
+                <widget fname="directory-of-resources-for-researchers" fail-silently="true"></widget>
               </div>
               <div flex-xs="100" class="widget-container">
-                <widget fname="madison-library-catalog"></widget>
+                <widget fname="madison-library-catalog" fail-silently="true"></widget>
               </div>
             </div>
 

--- a/web/src/main/webapp/my-app/search/partials/search-results.html
+++ b/web/src/main/webapp/my-app/search/partials/search-results.html
@@ -141,7 +141,8 @@
         </md-tab-label>
         <md-tab-body>
           <md-content>
-            <div layout="row" layout-align="center start" style="flex-wrap:wrap;padding:18px;">
+            <div layout="row" layout-align="center start"
+              style="flex-wrap:wrap;padding:18px;">
               <div flex-xs="100" class="widget-container">
                 <widget fname="wisc-kb" fail-silently="true"></widget>
               </div>
@@ -149,7 +150,8 @@
                 <widget fname="uwec-kb" fail-silently="true"></widget>
               </div>
               <div flex-xs="100" class="widget-container">
-                <widget fname="madison-public-course-search" fail-silently="true"></widget>
+                <widget fname="madison-public-course-search"
+                  fail-silently="true"></widget>
               </div>
               <div flex-xs="100" class="widget-container">
                 <widget fname="ResearcherPortlet" fail-silently="true"></widget>
@@ -161,10 +163,12 @@
                 <widget fname="ResearcherPortlet" fail-silently="true"></widget>
               </div>
               <div flex-xs="100" class="widget-container">
-                <widget fname="directory-of-resources-for-researchers" fail-silently="true"></widget>
+                <widget fname="directory-of-resources-for-researchers"
+                  fail-silently="true"></widget>
               </div>
               <div flex-xs="100" class="widget-container">
-                <widget fname="madison-library-catalog" fail-silently="true"></widget>
+                <widget fname="madison-library-catalog"
+                  fail-silently="true"></widget>
               </div>
             </div>
 

--- a/web/src/main/webapp/my-app/search/partials/search-results.html
+++ b/web/src/main/webapp/my-app/search/partials/search-results.html
@@ -18,6 +18,13 @@
     under the License.
 
 -->
+<style>
+  .widget-container {
+    max-width: 310px;
+    width: 290px;
+    margin: 4px 8px;
+  }
+</style>
 <frame-page app-title="Search results" app-icon="search" page-title="Search results" white-background="true">
   <md-content class="search-results">
     <p class="search-term">Showing results for <span>"{{ searchTerm }}"</span></p>
@@ -127,6 +134,44 @@
           </md-content>
         </md-tab-body>
       </md-tab>
+
+      <md-tab>
+        <md-tab-label>
+          Other
+        </md-tab-label>
+        <md-tab-body>
+          <md-content>
+            <div layout="row" layout-align="center start" style="flex-wrap:wrap;padding:18px;">
+              <div flex-xs="100" class="widget-container">
+                <widget fname="wisc-kb"></widget>
+              </div>
+              <div flex-xs="100" class="widget-container">
+                <widget fname="uwec-kb"></widget>
+              </div>
+              <div flex-xs="100" class="widget-container">
+                <widget fname="madison-public-course-search"></widget>
+              </div>
+              <div flex-xs="100" class="widget-container">
+                <widget fname="ResearcherPortlet"></widget>
+              </div>
+              <div flex-xs="100" class="widget-container">
+                <widget fname="rprg"></widget>
+              </div>
+              <div flex-xs="100" class="widget-container">
+                <widget fname="ResearcherPortlet"></widget>
+              </div>
+              <div flex-xs="100" class="widget-container">
+                <widget fname="directory-of-resources-for-researchers"></widget>
+              </div>
+              <div flex-xs="100" class="widget-container">
+                <widget fname="madison-library-catalog"></widget>
+              </div>
+            </div>
+
+            </md-content>
+          </md-tab-body>
+        </md-tab>
+
     </md-tabs>
   </md-content>
 </frame-page>


### PR DESCRIPTION
As a way to showcase widgets that launch searches.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
