### PR TITLE
Recognize Paulina Nogal as committer

### DIFF
--- a/committers.md
+++ b/committers.md
@@ -3,6 +3,7 @@
 ## Who are the committers?
 
 + [Christian Murphy][Christian Murphy committer election record] ( @ChristianMurphy )
++ Paulina Nogal ( @nogalpaulina )
 + Andrew Petro ( @apetro )
 + Doug Reed ( @Doug-Reed )
 + Dave Sibley ( @davidmsibley )


### PR DESCRIPTION
Recognize Paulina Nogal as committer,

on the basis of [contributions to uPortal-app-framework](https://github.com/uPortal-Project/uportal-app-framework/commits?author=nogalpaulina).

See also in context of uPortal-app-framework: https://github.com/uPortal-Project/uportal-app-framework/pull/953 .

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements

----

Tracked internally to MyUW as [MYUWADMIN-962](https://jira.doit.wisc.edu/jira/browse/MYUWADMIN-962).