### PR TITLE
depend on snapshot not release

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -42,7 +42,7 @@
       <groupId>org.apereo.uportal</groupId>
       <artifactId>uportal-app-framework</artifactId>
       <type>war</type>
-      <version>14.0.2</version>
+      <version>14.0.2-SNAPSHOT</version>
     </dependency>
 
     <!-- Test -->


### PR DESCRIPTION
HEAD typically depends on framework snapshot so as to use latest framework in development; uses concrete release version momentarily when releasing.

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
