### PR TITLE
Remove "popularity" sorting in app directory browse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
   (the now preferred URL-to-an-SVG-file way of referencing icons).
   so that app directory details pages show the entry icon rather than defaulting
   to showing a star icon.
++ remove "popularity" sorting option when browsing app directory entries,
+  since users are no longer able to rate entries.
++ tell users how many entries match
+  when filtering when browsing the app directory
 
 ## 10.2.2 - 2020-04-14
 

--- a/web/src/main/webapp/my-app/marketplace/controllers.js
+++ b/web/src/main/webapp/my-app/marketplace/controllers.js
@@ -266,11 +266,6 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
         $controller('MarketplaceCommonFunctionsController',
           {$scope: $scope});
 
-        $scope.specifyCategory = function(category) {
-          currentCategory=category;
-          currentPage='details';
-        };
-
         var figureOutBackStuff = function() {
           var fromInfo = marketplaceService.getFromInfo();
           if (fromInfo.term) {

--- a/web/src/main/webapp/my-app/marketplace/controllers.js
+++ b/web/src/main/webapp/my-app/marketplace/controllers.js
@@ -127,34 +127,6 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
         );
       };
 
-      $scope.selectFilter = function(filter, category) {
-        $scope.sortParameter = filter;
-        $scope.categoryToShow = category;
-        $scope.showCategories = false;
-        if (filter === 'popular') {
-          $scope.selectedFilter = 'popular';
-          $scope.sortParameter = ['-rating', '-userRated'];
-        }
-        if (filter === 'az') {
-          $scope.selectedFilter = 'az';
-          $scope.sortParameter = 'title';
-        }
-        if (filter === 'category') {
-          $scope.selectedFilter = 'category';
-          $scope.sortParameter = 'title';
-          $scope.showCategories = true;
-        }
-
-        miscService.pushGAEvent('Marketplace', 'Tab Select', filter);
-      };
-
-      $scope.slideTabs = function(direction) {
-        $scope.tabsPosition = 'start';
-        if (direction === 'right') {
-          $scope.tabsPosition = 'end';
-        }
-      };
-
       $scope.toggleShowAll = function() {
         $scope.showAll = !$scope.showAll;
       };
@@ -268,31 +240,15 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
           return true;
         });
 
-        if (currentPage === 'details') {
           // Empty string indicates no categories, show all portlets
           $scope.categoryToShow = '';
-          // Default to filter by category on return back to app dir browse
-          $scope.selectedFilter = 'category';
-          // When filtering by category, sort by title
-          $scope.sortParameter = 'title';
-          // Show category selection div by default
-          $scope.showCategories = true;
 
+          // Default to alphabetical sort by title on return to app dir browse
+          $scope.selectedFilter = 'az';
+          $scope.sortParameter = 'title';
+
+        if (currentPage === 'details') {
           currentPage = 'market';
-          if (currentCategory !== '') {
-            $scope.categoryToShow = currentCategory;
-          } else {
-            $scope.categoryToShow = '';
-          }
-        } else {
-          // Empty string indicates no categories, show all portlets
-          $scope.categoryToShow = '';
-          // Default filter is to sort by popularity
-          $scope.selectedFilter = 'popular';
-          // To sort by popularity, angular will use portlet.rating to filter
-          $scope.sortParameter = ['-rating', '-userRated'];
-          // Hide category selection div by default
-          $scope.showCategories = false;
         }
 
         base.initializeConstants();

--- a/web/src/main/webapp/my-app/marketplace/controllers.js
+++ b/web/src/main/webapp/my-app/marketplace/controllers.js
@@ -20,7 +20,6 @@
 
 define(['angular', 'jquery', 'require'], function(angular, $, require) {
   var currentPage = 'market';
-  var currentCategory = '';
 
   return angular.module('my-app.marketplace.controllers', [])
 

--- a/web/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/web/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -42,35 +42,10 @@
     </md-card>
 
     <md-card>
-      <div class="mp-tabs-container">
-        <div class="mp-prev-button" ng-click="slideTabs('left')">
-          <i class="fa fa-chevron-left"></i>
-        </div>
-        <div class="mp-next-button" ng-click="slideTabs('right')">
-          <i class="fa fa-chevron-right"></i>
-        </div>
-        <div class="mp-tabs-canvas">
-          <ul class="mp-tabs" ng-class="{true:'slide-right'}[tabsPosition === 'end']">
-            <li class="mp-tab md-ink-ripple" ng-click="selectFilter('popular','')"
-                ng-class="{true:'active'}[selectedFilter === 'popular']"
-                ng-style="selectedFilter === 'popular' && {color: primaryColorRgb}">
-              <span aria-label="Sort by popularity">Popular</span>
-              <div class="mp-tabs-slide" ng-style="{background: primaryColorRgb}"></div>
-            </li>
-            <li class="mp-tab md-ink-ripple" ng-click="selectFilter('az','')"
-                ng-class="{true: 'active'}[selectedFilter === 'az']"
-                ng-style="selectedFilter === 'az' && {color: primaryColorRgb}">
-              <span aria-label="Sort by alphabetical order">A-Z</span>
-              <div class="mp-tabs-slide" ng-style="{background: primaryColorRgb}"></div>
-            </li>
-          </ul>
-        </div>
-      </div>
-
       <loading-gif data-object="portlets" layout="row" layout-align="center center"></loading-gif>
 
       <div class="portlet-container"
-           ng-repeat="portlet in portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow | orderBy:sortParameter | limitTo:searchResultLimit"
+           ng-repeat="portlet in portlets | filter:searchTermFilter | showApplicable:showAll |  orderBy:sortParameter | limitTo:searchResultLimit"
            ng-class="{portlet_hover: hover}"
            ng-mouseenter="hover = true"
            ng-mouseleave="hover = false"
@@ -79,9 +54,9 @@
       </div>
 
       <marketplace-load-more
-        ng-show="portlets.length > 0 && (portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length > searchResultLimit"></marketplace-load-more>
+        ng-show="portlets.length > 0 && (portlets | filter:searchTermFilter | showApplicable:showAll ).length > searchResultLimit"></marketplace-load-more>
       <marketplace-no-results
-        ng-show="portlets.length > 0 && (portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length == 0"></marketplace-no-results>
+        ng-show="portlets.length > 0 && (portlets | filter:searchTermFilter | showApplicable:showAll ).length == 0"></marketplace-no-results>
     </md-card>
   </div>
 </frame-page>

--- a/web/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/web/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -44,6 +44,13 @@
     <md-card>
       <loading-gif data-object="portlets" layout="row" layout-align="center center"></loading-gif>
 
+      <md-card-title ng-show="portlets.length">
+        <md-card-title-text>
+          <span ng-show="portlets.length > 0 && !searchTerm">{{portlets.length}} entries are available to you</span>
+          <span ng-show="portlets.length > 0 && searchTerm">{{(portlets | filter:searchTermFilter | showApplicable:showAll ).length}} entries matching &quot;{{searchTerm}}&quot; are available to you</span>
+        </md-card-title-text>
+      </md-card-title>
+
       <div class="portlet-container"
            ng-repeat="portlet in portlets | filter:searchTermFilter | showApplicable:showAll |  orderBy:sortParameter | limitTo:searchResultLimit"
            ng-class="{portlet_hover: hover}"


### PR DESCRIPTION
Since users are no longer able to rate entries, stop sorting entries by rating when browsing. Sort alphabetically instead.

This unblocks truncating the ratings table to reduce friction in maintaining content.

Also, tell users how many entries match their browse filter.

Before:

![screenshot of status quo popularity sorting without filter](https://user-images.githubusercontent.com/952283/86498668-79644500-bd4c-11ea-85e9-983662ec29fa.png)

![screenshot of status quo popularity sorting with filter](https://user-images.githubusercontent.com/952283/86498675-7e28f900-bd4c-11ea-87eb-54904da9abd1.png)


After: 

![screenshot of new only-alpha sorting](https://user-images.githubusercontent.com/952283/86498684-8d0fab80-bd4c-11ea-92f2-71d35ef944e3.png)

![screenshot of new alpha-sorted filtered with quantity expectation setting](https://user-images.githubusercontent.com/952283/86498680-897c2480-bd4c-11ea-9841-5a6969fc0af7.png)




----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
