### PR TITLE
omit widget context menu on widget on details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Next
+
++ Excludes the widget context menu on the widget rendered on the details page
+  about an app directory entry.
 
 ## 10.2.2 - 2020-07-22
 

--- a/web/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
+++ b/web/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
@@ -54,7 +54,8 @@
         <!-- WIDGET PREVIEW -->
         <div class="preview">
           <div class="middle">
-            <widget fname="{{ portlet.fname }}"></widget>
+            <widget fname="{{ portlet.fname }}"
+              include-context-menu="false"></widget>
           </div>
           <md-button class="md-raised md-primary fixed-width fname-{{::portlet.fname}}"
                      ng-click="addToHome(portlet)"


### PR DESCRIPTION
On the details page about an app directory entry, when previewing its widget, omit the context menu on the widget.
It contains the description, which is already rendered on the page, and a link to the details page, the selfsame page the
user is already looking at.

Makes the details page slightly less busy, and demonstrates the new `include-context-menu` attribute on the `widget` directive.

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
