### PR TITLE
Use uportal-app-framework 17.0.3-SNAPSHOT

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -42,7 +42,7 @@
       <groupId>org.apereo.uportal</groupId>
       <artifactId>uportal-app-framework</artifactId>
       <type>war</type>
-      <version>17.0.2</version>
+      <version>17.0.3-SNAPSHOT</version>
     </dependency>
 
     <!-- Test -->


### PR DESCRIPTION
uPortal-home:master routinely relies upon latest SNAPSHOT produced by uPortal-app-framework:master . When releasing, app-framework produces a release version, and the uPortal-home release depends upon that release version for its release and then past the release again depends upon the latest SNAPSHOT. In this way uPortal-home releases depend upon stable versioned releases of app framework, but routine development and deployment of latest uPortal-home (e.g. on predev) routinely demonstrates against latest app framework.

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
