### PR TITLE
Migrate old layouts to new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 Versions in this document should match those
 [published to Sonatype Maven Central Repository][].
 
+## Next
+
++ Automate migrating layout from old layout backend to new layout backend.
+
 ## 13.0.0 - 2021-04-23
 
 + Built on [uPortal-app-framework 20.0.0.][]

--- a/web/src/main/webapp/my-app/layout/services.js
+++ b/web/src/main/webapp/my-app/layout/services.js
@@ -115,7 +115,7 @@ define(['angular', 'jquery'], function(angular, $) {
 
           var removeFromHome = function removeFromHomeFunction(fname) {
             return getLayout().then(function(data) {
-              var newLayout = data.layout.filter(function(val){
+              var newLayout = data.layout.filter(function(val) {
                 return val !== fname;
               });
               return $http({

--- a/web/src/main/webapp/my-app/layout/services.js
+++ b/web/src/main/webapp/my-app/layout/services.js
@@ -69,16 +69,35 @@ define(['angular', 'jquery'], function(angular, $) {
                 var formattedOldLayout = formatLayoutForCache(result.data);
 
                 $log.log('persistAndUse: formatted old layout data as: ' + formattedOldLayout.layout);
+                // Parse out the fnames from the old layout JSON
+                // The array of fnames is the new layout
+                // Publish that to the new backend, and use it.
+                // Old format:
+                //  {layout: [ {"fname": "some-fname", ...}, {"fname": "some-other-fname", ...}]}
+                // New format:
+                //  {layout: ["some-fname", "some-other-fname"]}
+
+                var oldArrayOfMaps = formattedOldLayout.layout;
+                var newLayoutRepresentation = [];
+
+                for (var i = 0; i < oldArrayOfMaps.length; i++) {
+                  var fname = oldArrayOfMaps[i].fname;
+                  $log.log('Object in the array is ' + angular.toJson(oldArrayOfMaps[i]));
+                  $log.log('fname is ' + fname);
+                  newLayoutRepresentation.push(fname);
+                }
+
+                $log.log('persistAndUse: parsed to fname array representation: ' + newLayoutRepresentation);
                 // persist the old layout to the new layout store
                 $http({
                   method: 'POST',
                   url: SERVICE_LOC.newLayout,
-                  data: {'layout': formattedOldLayout, 'new': false},
+                  data: {'layout': newLayoutRepresentation, 'new': false},
                   dataType: 'json',
                 });
 
-                storeLayoutInCache(formattedOldLayout);
-                return formattedOldLayout;
+                storeLayoutInCache({'layout': newLayoutRepresentation, 'new': false});
+                return {'layout': newLayoutRepresentation, 'new': false};
               };
 
               successFn = function(result) {

--- a/web/src/main/webapp/my-app/layout/services.js
+++ b/web/src/main/webapp/my-app/layout/services.js
@@ -124,7 +124,7 @@ define(['angular', 'jquery'], function(angular, $) {
                   data: {'layout': newLayout, 'new': false},
                   dataType: 'json',
               });
-            })
+            });
           };
 
           var moveStuff = function moveStuffFunction() {

--- a/web/src/main/webapp/my-app/layout/services.js
+++ b/web/src/main/webapp/my-app/layout/services.js
@@ -45,6 +45,7 @@ define(['angular', 'jquery'], function(angular, $) {
           $log.log('using new layout');
 
           var getLayout = function() {
+            $log.log('getLayout (new backend version)');
             return checkLayoutCache().then(function(data) {
               var successFn;
               var errorFn;
@@ -52,18 +53,22 @@ define(['angular', 'jquery'], function(angular, $) {
 
               // first, check the local storage...
               if (data) {
+                $log.log('getLayout (new version): found layout in cache: ' + data);
                 defer = $q.defer();
                 defer.resolve(data);
                 return defer.promise;
               }
+              $log.log('getlayout (new version) did not find layout in cache');
 
               /**
                * Persists old layout data as new layout and uses that old-is-new
                * layout in current session.
                */
               var persistAndUse = function(result) {
+                $log.log('persistAndUse: got data from old layout backend: ' + result.data.layout);
                 var formattedOldLayout = formatLayoutForCache(result.data);
 
+                $log.log('persistAndUse: formatted old layout data as: ' + formattedOldLayout.layout);
                 // persist the old layout to the new layout store
                 $http({
                   method: 'POST',
@@ -77,7 +82,9 @@ define(['angular', 'jquery'], function(angular, $) {
               };
 
               successFn = function(result) {
+                $log.log('successFn with data from new layout service: ' + result.data.layout);
                 if (result.data.new) {
+                  $log.log('User is new to the new layout service.');
                   // oh! It's a new user never before seen by new layout service.
                   // check the old layout service for the user's old layout
                   // and paste it into the new service.
@@ -85,7 +92,9 @@ define(['angular', 'jquery'], function(angular, $) {
                     SERVICE_LOC.context + SERVICE_LOC.layout, {cache: true} )
                       .then(persistAndUse);
                 } else {
+                  $log.log('User is NOT new to new layout service.');
                   var data = formatLayoutForCache(result.data);
+                  $log.log('Formatted new layout data as ' + data.layout);
                   storeLayoutInCache(data);
                   return data;
                 }

--- a/web/src/main/webapp/my-app/layout/services.js
+++ b/web/src/main/webapp/my-app/layout/services.js
@@ -42,7 +42,7 @@ define(['angular', 'jquery'], function(angular, $) {
         ************************/
 
         if (APP_FLAGS.useNewLayout) {
-          console.log("using new layout");
+          $log.log('using new layout');
 
           var getLayout = function() {
             return checkLayoutCache().then(function(data) {
@@ -121,7 +121,7 @@ define(['angular', 'jquery'], function(angular, $) {
               return $http({
                   method: 'POST',
                   url: SERVICE_LOC.newLayout,
-                  data: {"layout" : newLayout, "new" : false},
+                  data: {'layout': newLayout, 'new': false},
                   dataType: 'json'
               });
             })

--- a/web/src/main/webapp/my-app/layout/services.js
+++ b/web/src/main/webapp/my-app/layout/services.js
@@ -122,7 +122,7 @@ define(['angular', 'jquery'], function(angular, $) {
                   method: 'POST',
                   url: SERVICE_LOC.newLayout,
                   data: {'layout': newLayout, 'new': false},
-                  dataType: 'json'
+                  dataType: 'json',
               });
             })
           };

--- a/web/src/main/webapp/my-app/layout/services.js
+++ b/web/src/main/webapp/my-app/layout/services.js
@@ -35,7 +35,7 @@ define(['angular', 'jquery'], function(angular, $) {
       function($sce, $http, $log, miscService,
         mainService, $sessionStorage, $q, SERVICE_LOC, APP_FLAGS) {
 
-        /************************
+        /**
         * NEW LAYOUT
         * To use new service layout set useNewLayout flag in override.js to true,
         * and useOldLayout to false
@@ -142,7 +142,7 @@ define(['angular', 'jquery'], function(angular, $) {
           };
         }
 
-        /************************
+        /**
         ** OLD LAYOUT
         ** To use old service layout set useOldLayout flag in override.js to true,
         ** and useNewLayout to false

--- a/web/src/main/webapp/my-app/layout/services.js
+++ b/web/src/main/webapp/my-app/layout/services.js
@@ -79,10 +79,10 @@ define(['angular', 'jquery'], function(angular, $) {
               return $http({
                 method: 'POST',
                 url: SERVICE_LOC.newLayout,
-                data: {"layout" : newLayout, "new" : false},
-                dataType: 'json'
+                data: {'layout': newLayout, 'new': false},
+                dataType: 'json',
               });
-            })
+            });
           };
 
           var removeFromHome = function removeFromHomeFunction(fname) {


### PR DESCRIPTION
Automates migrating from old layout back-end to new back-end.

If the user is new to the new back-end,
query their layout from the old back end and publish it to the new back-end.
Otherwise, just use the new back-end.

Credit to @nogalpaulina : this resulted from working on this together.