### PR TITLE
Remove KeepFocus directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versions in this document should match those
 
 + Automate migrating layout from old layout backend to new layout backend.
 + Ensure there are no duplicate fnames in layout
++ Remove ineffectual KeepFocus directive
 
 ## 13.0.0 - 2021-04-23
 

--- a/web/src/main/webapp/my-app/layout/directives.js
+++ b/web/src/main/webapp/my-app/layout/directives.js
@@ -55,24 +55,5 @@ define(['angular', 'require'], function(angular, require) {
           restrict: 'E',
           templateUrl: require.toUrl('./partials/remove-button.html'),
       };
-    })
-    .directive('keepFocus', function($timeout) {
-      return {
-        restrict: 'A',
-        scope: {
-          nodeId: '@',
-          index: '@',
-          selectedNodeId: '@',
-        },
-        link: function($scope, $element, attrs) {
-          $scope.$watch('index', function(currentValue, previousValue) {
-            if ($scope.nodeId === $scope.selectedNodeId) {
-              $timeout(function() {
-                $element[0].focus();
-              });
-            }
-          });
-        },
-      };
     });
 });

--- a/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
+++ b/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
@@ -36,7 +36,6 @@
       <li class="no-padding widget-container"
           tabindex="0"
           aria-label="{{ widget.title }}"
-          keep-focus
           node-id="{{ widget.nodeId }}"
           selected-node-id="{{ selectedNodeId }}"
           index="{{ $index }}"

--- a/web/src/main/webapp/my-app/layout/widget/partials/home-widget-view.html
+++ b/web/src/main/webapp/my-app/layout/widget/partials/home-widget-view.html
@@ -34,7 +34,6 @@
       <li class="no-padding widget-container"
           tabindex="0"
           aria-label="{{ widget.title }}"
-          keep-focus
           node-id="{{ widget.nodeId }}"
           selected-node-id="{{ selectedNodeId }}"
           index="{{ $index }}"


### PR DESCRIPTION
Remove ineffectual `KeepFocus` directive. There are no comments related to the purpose of this directive, and therefore I would like to propose removing it from the app, as it's putting the focus on unexpected elements.

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
