### PR TITLE
style: address some eslint flagged issues in /layout/services.js 

### DIFF
--- a/web/src/main/webapp/my-app/layout/services.js
+++ b/web/src/main/webapp/my-app/layout/services.js
@@ -173,7 +173,7 @@ define(['angular', 'jquery'], function(angular, $) {
                   method: 'POST',
                   url: SERVICE_LOC.newLayout,
                   data: {'layout': newLayout, 'new': false},
-                  dataType: 'json'
+                  dataType: 'json',
               });
             });
           };

--- a/web/src/main/webapp/my-app/layout/services.js
+++ b/web/src/main/webapp/my-app/layout/services.js
@@ -37,7 +37,8 @@ define(['angular', 'jquery'], function(angular, $) {
 
         /**
         * NEW LAYOUT
-        * To use new service layout set useNewLayout flag in override.js to true,
+        * To use new service layout
+        * set useNewLayout flag in override.js to true,
         * and useOldLayout to false
         ************************/
 
@@ -52,7 +53,8 @@ define(['angular', 'jquery'], function(angular, $) {
               var defer;
               // first, check the local storage...
               if (data) {
-                $log.log('getLayout (new version): found layout in cache: ' + data);
+                $log.log('getLayout (new version): found layout in cache: ' +
+                  data);
                 defer = $q.defer();
                 defer.resolve(data);
                 return defer.promise;
@@ -64,15 +66,18 @@ define(['angular', 'jquery'], function(angular, $) {
                * layout in current session.
                */
               var persistAndUse = function(result) {
-                $log.log('persistAndUse: got data from old layout backend: ' + result.data.layout);
+                $log.log('persistAndUse: got data from old layout backend: ' +
+                  result.data.layout);
                 var formattedOldLayout = formatLayoutForCache(result.data);
 
-                $log.log('persistAndUse: formatted old layout data as: ' + formattedOldLayout.layout);
+                $log.log('persistAndUse: formatted old layout data as: ' +
+                  formattedOldLayout.layout);
                 // Parse out the fnames from the old layout JSON
                 // The array of fnames is the new layout
                 // Publish that to the new backend, and use it.
                 // Old format:
-                //  {layout: [ {"fname": "some-fname", ...}, {"fname": "some-other-fname", ...}]}
+                //  {layout: [ {"fname": "some-fname", ...},
+                // {"fname": "some-other-fname", ...}]}
                 // New format:
                 //  {layout: ["some-fname", "some-other-fname"]}
 
@@ -81,12 +86,15 @@ define(['angular', 'jquery'], function(angular, $) {
 
                 for (var i = 0; i < oldArrayOfMaps.length; i++) {
                   var fname = oldArrayOfMaps[i].fname;
-                  $log.log('Object in the array is ' + angular.toJson(oldArrayOfMaps[i]));
+                  $log.log('Object in the array is ' +
+                    angular.toJson(oldArrayOfMaps[i]));
                   $log.log('fname is ' + fname);
                   newLayoutRepresentation.push(fname);
                 }
 
-                $log.log('persistAndUse: parsed to fname array representation: ' + newLayoutRepresentation);
+                $log.log('persistAndUse: ' +
+                  'parsed to fname array representation: ' +
+                  newLayoutRepresentation);
                 // persist the old layout to the new layout store
                 $http({
                   method: 'POST',
@@ -95,15 +103,18 @@ define(['angular', 'jquery'], function(angular, $) {
                   dataType: 'json',
                 });
 
-                storeLayoutInCache({'layout': newLayoutRepresentation, 'new': false});
+                storeLayoutInCache(
+                  {'layout': newLayoutRepresentation, 'new': false});
                 return {'layout': newLayoutRepresentation, 'new': false};
               };
 
               successFn = function(result) {
-                $log.log('successFn with data from new layout service: ' + result.data.layout);
+                $log.log('successFn with data from new layout service: ' +
+                  result.data.layout);
                 if (result.data.new) {
                   $log.log('User is new to the new layout service.');
-                  // oh! It's a new user never before seen by new layout service.
+                  // oh! It's a new user
+                  // never before seen by new layout service.
                   // check the old layout service for the user's old layout
                   // and paste it into the new service.
                   return $http.get(
@@ -172,7 +183,8 @@ define(['angular', 'jquery'], function(angular, $) {
 
         /**
         ** OLD LAYOUT
-        ** To use old service layout set useOldLayout flag in override.js to true,
+        ** To use old service layout
+        ** set useOldLayout flag in override.js to true,
         ** and useNewLayout to false
         *************************/
 

--- a/web/src/main/webapp/my-app/layout/services.js
+++ b/web/src/main/webapp/my-app/layout/services.js
@@ -172,7 +172,7 @@ define(['angular', 'jquery'], function(angular, $) {
                 return $http({
                   method: 'POST',
                   url: SERVICE_LOC.newLayout,
-                  data: {'layout' : newLayout, 'new' : false},
+                  data: {'layout': newLayout, 'new': false},
                   dataType: 'json'
               });
             });

--- a/web/src/main/webapp/my-app/layout/services.js
+++ b/web/src/main/webapp/my-app/layout/services.js
@@ -187,7 +187,7 @@ define(['angular', 'jquery'], function(angular, $) {
         *************************/
 
         if (APP_FLAGS.useOldLayout) {
-          console.log('using old layout');
+          $log.log('using old layout');
 
           var getLayout = function() {
             return checkLayoutCache().then(function(data) {
@@ -289,7 +289,7 @@ define(['angular', 'jquery'], function(angular, $) {
         }
 
         var getUncachedLayout = function() {
-          console.log('in getUncachedLayout');
+          $log.log('in getUncachedLayout');
           var successFn = function(result) {
               var data = formatLayoutForCache(result.data);
               storeLayoutInCache(data);

--- a/web/src/main/webapp/my-app/layout/services.js
+++ b/web/src/main/webapp/my-app/layout/services.js
@@ -355,7 +355,7 @@ define(['angular', 'jquery'], function(angular, $) {
             'layout': [],
           };
           //  Check if there are duplicate fnames in data.layout
-          var filteredDataLayout = data.layout.filter(function (item, ind) {
+          var filteredDataLayout = data.layout.filter(function(item, ind) {
               return data.layout.indexOf(item) == ind;
           });
 

--- a/web/src/main/webapp/my-app/layout/services.js
+++ b/web/src/main/webapp/my-app/layout/services.js
@@ -162,7 +162,7 @@ define(['angular', 'jquery'], function(angular, $) {
                 return $http({
                   method: 'POST',
                   url: SERVICE_LOC.newLayout,
-                  data: {"layout" : newLayout, "new" : false},
+                  data: {'layout' : newLayout, 'new' : false},
                   dataType: 'json'
               });
             });
@@ -177,7 +177,7 @@ define(['angular', 'jquery'], function(angular, $) {
         *************************/
 
         if (APP_FLAGS.useOldLayout) {
-          console.log("using old layout");
+          console.log('using old layout');
 
           var getLayout = function() {
             return checkLayoutCache().then(function(data) {
@@ -279,7 +279,7 @@ define(['angular', 'jquery'], function(angular, $) {
         }
 
         var getUncachedLayout = function() {
-          console.log("in getUncachedLayout");
+          console.log('in getUncachedLayout');
           var successFn = function(result) {
               var data = formatLayoutForCache(result.data);
               storeLayoutInCache(data);

--- a/web/src/main/webapp/my-app/layout/services.js
+++ b/web/src/main/webapp/my-app/layout/services.js
@@ -34,7 +34,6 @@ define(['angular', 'jquery'], function(angular, $) {
       'mainService', '$sessionStorage', '$q', 'SERVICE_LOC', 'APP_FLAGS',
       function($sce, $http, $log, miscService,
         mainService, $sessionStorage, $q, SERVICE_LOC, APP_FLAGS) {
-
         /**
         * NEW LAYOUT
         * To use new service layout
@@ -177,7 +176,6 @@ define(['angular', 'jquery'], function(angular, $) {
                   dataType: 'json'
               });
             });
-
           };
         }
 


### PR DESCRIPTION
Addresses the easy-to-address nonstandard style flagged by eslint.

Before: more lines lighting up

![screenshot showing more lines flagged before this changeset](https://user-images.githubusercontent.com/952283/141545447-956d56e5-56dc-44fb-9861-75eed36f0dec.png)


After: fewer lines lighting up

![screenshot showing fewer flagged lines after this changeset](https://user-images.githubusercontent.com/952283/141543527-6bce8115-1253-4b02-9e77-c47a12899f24.png)

No functional change.
