### PR TITLE
drop duplicate fnames when migrating layout from old layout backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Versions in this document should match those
 
 ## Next
 
++ Drops duplicate fnames when migrating from old layout backend
+  to new layout backend.
+
 ## 14.0.1 - 2021-11-22
 
 + Built on [uPortal-app-framework 21.0.2][].

--- a/web/src/main/webapp/my-app/layout/services.js
+++ b/web/src/main/webapp/my-app/layout/services.js
@@ -83,12 +83,19 @@ define(['angular', 'jquery'], function(angular, $) {
                 var oldArrayOfMaps = formattedOldLayout.layout;
                 var newLayoutRepresentation = [];
 
+                // use a Set to drop subsequent duplicates when migrating
+                var fnameSet = new Set();
                 for (var i = 0; i < oldArrayOfMaps.length; i++) {
                   var fname = oldArrayOfMaps[i].fname;
                   $log.log('Object in the array is ' +
                     angular.toJson(oldArrayOfMaps[i]));
                   $log.log('fname is ' + fname);
-                  newLayoutRepresentation.push(fname);
+                  if (!fnameSet.has(fname)) {
+                    fnameSet.add(fname);
+                    newLayoutRepresentation.push(fname);
+                  } else {
+                    $log.log('Dropped duplicate fname ' + fname);
+                  }
                 }
 
                 $log.log('persistAndUse: ' +


### PR DESCRIPTION
The new layout backend [assures no duplicates](https://git.doit.wisc.edu/myuw/layout-service/-/blob/main/test/layout_service/core_test.clj#L361).

But when migrating layouts, this front end would POST the copied over layout to the new backend, but did not read the layout back out of the new backend, and so did not immediately benefit from the backend's de-duplication.

This Pull Request adds using Set to filter away duplicate fnames client-side during the migration process.
