### PR TITLE
Removes white border style when hovering over 'Add more to home'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 Versions in this document should match those
 [published to Sonatype Maven Central Repository][].
 
+## Next
++ Removes white border style when hovering over 'Add more to home' on compact layout
 ## 14.0.2 - 2021-11-22
 
 + Drops duplicate fnames when migrating from old layout backend

--- a/web/src/main/webapp/css/home.less
+++ b/web/src/main/webapp/css/home.less
@@ -263,6 +263,16 @@ div.table-cell {
   }
 }
 
+.layout-list__compact {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  justify-content: center;
+  .add-favorites:hover {
+    border: none;
+  }
+}
+
 // View Toggle
 .home-title {
   padding: 0 0 0 15px;


### PR DESCRIPTION
Removes white border style when hovering over 'Add more to home' on compact layout

Before:
<img width="1180" alt="Screen Shot 2022-01-21 at 12 49 13 PM" src="https://user-images.githubusercontent.com/10341961/150593742-1e55e7a3-91bc-4b4b-b17a-5c85dac5c274.png">

After:
<img width="1168" alt="Screen Shot 2022-01-21 at 2 02 44 PM" src="https://user-images.githubusercontent.com/10341961/150593755-1fe91f2a-04fc-45d3-b366-8348176f080e.png">

----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
