### PR TITLE
Improve accessibility of tabbing through widgets in compact mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 Versions in this document should match those
 [published to Sonatype Maven Central Repository][].
 
+## Next
++ Removes white border style when hovering over 'Add more to home' on compact layout
 ## 14.0.2 - 2021-11-22
 
 + Drops duplicate fnames when migrating from old layout backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to
 Versions in this document should match those
 [published to Sonatype Maven Central Repository][].
 
-## Next
+## 14.0.3 - 2022-02-04
++ Removes unnecessary taindex from list items surrounding widgets
 + Removes white border style when hovering over 'Add more to home' on compact layout
 ## 14.0.2 - 2021-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ Versions in this document should match those
 [published to Sonatype Maven Central Repository][].
 
 ## 14.0.3 - 2022-02-04
-+ Removes unnecessary taindex from list items surrounding widgets
+
++ Adds tabindex to Add to home button as a fix for button being inaccessible in Firefox
++ Removes unnecessary tabindex from list items surrounding widgets
 + Removes white border style when hovering over 'Add more to home' on compact layout
 ## 14.0.2 - 2021-11-22
 

--- a/web/src/main/webapp/css/home.less
+++ b/web/src/main/webapp/css/home.less
@@ -263,6 +263,16 @@ div.table-cell {
   }
 }
 
+.layout-list__compact {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  justify-content: center;
+  .add-favorites:hover {
+    border: none;
+  }
+}
+
 // View Toggle
 .home-title {
   padding: 0 0 0 15px;

--- a/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
+++ b/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
@@ -34,7 +34,6 @@
         class="layout-list compact">
       <li class="dndPlaceholder no-padding widget-container"></li>
       <li class="no-padding widget-container"
-          tabindex="0"
           aria-label="{{ widget.title }}"
           node-id="{{ widget.nodeId }}"
           selected-node-id="{{ selectedNodeId }}"

--- a/web/src/main/webapp/my-app/layout/partials/marketplace-light.html
+++ b/web/src/main/webapp/my-app/layout/partials/marketplace-light.html
@@ -19,7 +19,7 @@
 
 -->
 <div class="list-content add-favorites">
-   <a href='apps'>
+   <a href='apps' tabindex="0">
      <div class="icon-container">
        <i class="fa fa-plus"></i>
      </div>

--- a/web/src/main/webapp/my-app/layout/widget/partials/home-widget-view.html
+++ b/web/src/main/webapp/my-app/layout/widget/partials/home-widget-view.html
@@ -32,7 +32,6 @@
         class="layout-list">
       <example-widgets ng-if="$storage.exampleWidgets"></example-widgets>
       <li class="no-padding widget-container"
-          tabindex="0"
           aria-label="{{ widget.title }}"
           node-id="{{ widget.nodeId }}"
           selected-node-id="{{ selectedNodeId }}"


### PR DESCRIPTION
+ Adds tabindex to Add to home button as a fix for the button being inaccessible in Firefox.
Our developer noticed that Add to home isn't in the tab order (Both in expanded and in compact widget modes) when tabbing in Firefox 96.0 and in Safari 15.2 in the production environment. There's no evidence in the code that this interactive element was removed from the tab order, and should be accessible by default since it's a link `<a>`. I'm adding a `taindex="0"` to this element to ensure it's accessible in all browsers.

+ Removes unnecessary tabindex from list items surrounding widgets.
`tabindex="0"` was applied to `<li>` elements surrounding the actual widgets. This was causing additional and unnecessary steps when tabbing through the application's content.
----

Review for security considerations

<!-- Place an x in the checkbox for YES. -->

- [x] The change has been examined for security impact.

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
