### PR TITLE
build on frame 21.0.4-SNAPSHOT

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -42,7 +42,7 @@
       <groupId>org.apereo.uportal</groupId>
       <artifactId>uportal-app-framework</artifactId>
       <type>war</type>
-      <version>21.0.3</version>
+      <version>21.0.4-SNAPSHOT</version>
     </dependency>
 
     <!-- Test -->


### PR DESCRIPTION
build on [latest SNAPSHOT of uPortal-app-framework](https://github.com/uPortal-Project/uportal-app-framework/blob/master/pom.xml#L27), so that latest snapshot of uPortal-home builds on latest snapshot of uPortal-app-framework so that an environment running uPortal-home latest snapshot is using the latest everything.
